### PR TITLE
fix(tap): Support switch toggle activation

### DIFF
--- a/AxePlaygroundApp/AxePlayground/ContentView.swift
+++ b/AxePlaygroundApp/AxePlayground/ContentView.swift
@@ -55,6 +55,8 @@ struct ContentView: View {
             GesturePresetsView()
         case "landscape-coordinate-test":
             LandscapeCoordinateTestView()
+        case "switch-test":
+            SwitchTestView()
             
         // Input & Text
         case "text-input":
@@ -87,7 +89,8 @@ struct MainMenuView: View {
             ("touch-control", "Touch Control", "Touch down/up events"),
             ("swipe-test", "Swipe Test", "Shows CLI swipe paths"),
             ("gesture-presets", "Gesture Presets", "Multi-touch gesture display"),
-            ("landscape-coordinate-test", "Landscape Coordinates", "Verifies orientation-aware taps")
+            ("landscape-coordinate-test", "Landscape Coordinates", "Verifies orientation-aware taps"),
+            ("switch-test", "Switch Test", "SwiftUI and UIKit switch controls")
         ]),
         ("Input & Text", [
             ("text-input", "Text Input", "Text typed by CLI commands"),

--- a/AxePlaygroundApp/AxePlayground/Views/SwitchTestView.swift
+++ b/AxePlaygroundApp/AxePlayground/Views/SwitchTestView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+import UIKit
+
+struct SwitchTestView: View {
+    @State private var swiftUIWeatherAlertsEnabled = false
+    @State private var uiKitWeatherAlertsEnabled = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Text("Switch Playground")
+                .font(.title2)
+                .fontWeight(.bold)
+                .accessibilityIdentifier("switch-test-title")
+
+            VStack(alignment: .leading, spacing: 8) {
+                Toggle("SwiftUI Weather Alerts", isOn: $swiftUIWeatherAlertsEnabled)
+                    .accessibilityIdentifier("swiftui-weather-alerts-switch")
+                    .accessibilityLabel("SwiftUI Weather Alerts")
+
+                Text("SwiftUI Weather Alerts: \(swiftUIWeatherAlertsEnabled ? "On" : "Off")")
+                    .font(.headline)
+                    .accessibilityIdentifier("swiftui-weather-alerts-state")
+                    .accessibilityValue(swiftUIWeatherAlertsEnabled ? "On" : "Off")
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("UIKit Weather Alerts")
+                    Spacer()
+                    UIKitSwitch(
+                        isOn: $uiKitWeatherAlertsEnabled,
+                        accessibilityIdentifier: "uikit-weather-alerts-switch",
+                        accessibilityLabel: "UIKit Weather Alerts"
+                    )
+                    .frame(width: 60, height: 36)
+                }
+
+                Text("UIKit Weather Alerts: \(uiKitWeatherAlertsEnabled ? "On" : "Off")")
+                    .font(.headline)
+                    .accessibilityIdentifier("uikit-weather-alerts-state")
+                    .accessibilityValue(uiKitWeatherAlertsEnabled ? "On" : "Off")
+            }
+
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("Switch Test")
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("switch-test-screen")
+    }
+}
+
+private struct UIKitSwitch: UIViewRepresentable {
+    @Binding var isOn: Bool
+    let accessibilityIdentifier: String
+    let accessibilityLabel: String
+
+    func makeUIView(context: Context) -> UISwitch {
+        let uiSwitch = UISwitch()
+        uiSwitch.accessibilityIdentifier = accessibilityIdentifier
+        uiSwitch.accessibilityLabel = accessibilityLabel
+        uiSwitch.addTarget(
+            context.coordinator,
+            action: #selector(Coordinator.valueChanged(_:)),
+            for: .valueChanged
+        )
+        return uiSwitch
+    }
+
+    func updateUIView(_ uiView: UISwitch, context: Context) {
+        uiView.isOn = isOn
+        uiView.accessibilityIdentifier = accessibilityIdentifier
+        uiView.accessibilityLabel = accessibilityLabel
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isOn: $isOn)
+    }
+
+    final class Coordinator: NSObject {
+        private let isOn: Binding<Bool>
+
+        init(isOn: Binding<Bool>) {
+            self.isOn = isOn
+        }
+
+        @objc func valueChanged(_ sender: UISwitch) {
+            isOn.wrappedValue = sender.isOn
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SwitchTestView()
+    }
+}

--- a/BATCHING.md
+++ b/BATCHING.md
@@ -151,6 +151,15 @@ Default: `0.25`
 
 Lower values poll more aggressively (faster detection, more overhead). Higher values reduce overhead but increase detection latency.
 
+### `--tap-style <automatic|simulator|physical>`
+Controls the default tap event style for tap steps.
+
+- `automatic` (default): uses physical touch down/up for matched switches/toggles and FBSimulator `tapAt` for other targets.
+- `simulator`: always uses FBSimulator `tapAt`.
+- `physical`: always uses touch down/up.
+
+A tap step can override the batch default with its own `--tap-style` option.
+
 ### `--verbose`
 Enables detailed stderr logging for troubleshooting.
 
@@ -177,10 +186,14 @@ Each step command keeps its normal options and validation.
 
 Examples:
 - `tap --id BackButton`
+- `tap --label 'Weather Alerts'`
 - `tap -x 200 -y 400 --pre-delay 0.2 --post-delay 0.2`
 - `swipe --start-x 100 --start-y 300 --end-x 300 --end-y 100`
+- `tap -x 320 -y 780 --tap-style physical`
 - `gesture scroll-down --duration 1.0`
 - `touch -x 150 -y 300 --down --up --delay 1.0`
+
+Selector tap steps use the same activation behavior as direct `axe tap`: when a matched row or label contains exactly one UIKit `UISwitch` or SwiftUI `Toggle`/switch control, AXe taps the switch control instead of the row's geometric center. With the default `--tap-style automatic`, those switch/toggle activations use physical touch down/up; normal taps use FBSimulator `tapAt`.
 
 One important rule:
 - Do not include `--udid` inside a step. Use the batch-level `--udid` only.
@@ -224,6 +237,16 @@ axe batch --udid SIMULATOR_UDID \
   --step "sleep 0.5" \
   --step "tap --id SaveButton"
 ```
+
+## Real-world example: toggling a setting
+
+```bash
+axe batch --udid SIMULATOR_UDID \
+  --step "tap --label 'Weather Alerts'"
+```
+
+If the `Weather Alerts` row contains one switch/toggle control, AXe taps that control's activation point using physical touch in automatic tap style.
+
 
 ## Real-world example: multi-screen flow with element waiting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `tap`, `touch`, `swipe`, and matching batch steps dispatching logical UI coordinates directly to FBSimulatorHIDEvent without landscape rotation or letterbox correction, causing interactions to land in the wrong location in rotated landscape simulators and portrait-hardware landscape-only apps. AXe now detects the simulator UI orientation automatically instead of requiring callers to pass landscape flags ([#5](https://github.com/cameroncooke/AXe/issues/5) by [@Nitewriter](https://github.com/Nitewriter))
 - Fixed selector-based `tap` and batch tap steps so UIKit `UISwitch` and SwiftUI `Toggle` controls can be activated reliably, including when a matched row or label contains a single switch/toggle control. Added `--tap-style` so switch/toggle taps can use physical touch automatically while normal taps keep the simulator `tapAt` path by default.
+- Fixed element comparison in `AccessibilityTargetResolver` to prevent distinct elements with the same type and frame but lacking labels/values from being incorrectly identified as identical during ancestor tree traversal.
 
 ## [v1.6.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `tap`, `touch`, `swipe`, and matching batch steps dispatching logical UI coordinates directly to FBSimulatorHIDEvent without landscape rotation or letterbox correction, causing interactions to land in the wrong location in rotated landscape simulators and portrait-hardware landscape-only apps. AXe now detects the simulator UI orientation automatically instead of requiring callers to pass landscape flags ([#5](https://github.com/cameroncooke/AXe/issues/5) by [@Nitewriter](https://github.com/Nitewriter))
+- Fixed selector-based `tap` and batch tap steps so UIKit `UISwitch` and SwiftUI `Toggle` controls can be activated reliably, including when a matched row or label contains a single switch/toggle control. Added `--tap-style` so switch/toggle taps can use physical touch automatically while normal taps keep the simulator `tapAt` path by default.
 
 ## [v1.6.0] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `tap`, `touch`, `swipe`, and matching batch steps dispatching logical UI coordinates directly to FBSimulatorHIDEvent without landscape rotation or letterbox correction, causing interactions to land in the wrong location in rotated landscape simulators and portrait-hardware landscape-only apps. AXe now detects the simulator UI orientation automatically instead of requiring callers to pass landscape flags ([#5](https://github.com/cameroncooke/AXe/issues/5) by [@Nitewriter](https://github.com/Nitewriter))
-- Fixed selector-based `tap` and batch tap steps so UIKit `UISwitch` and SwiftUI `Toggle` controls can be activated reliably, including when a matched row or label contains a single switch/toggle control. Added `--tap-style` so switch/toggle taps can use physical touch automatically while normal taps keep the simulator `tapAt` path by default.
+- Fixed selector-based `tap` and batch tap steps so UIKit `UISwitch` and SwiftUI `Toggle` controls can be activated reliably, including when a matched row or label contains a single switch/toggle control. Added `--tap-style` so switch/toggle taps can use physical touch automatically while normal taps keep the simulator `tapAt` path by default ([#46](https://github.com/cameroncooke/AXe/pull/46)).
 - Fixed element comparison in `AccessibilityTargetResolver` to prevent distinct elements with the same type and frame but lacking labels/values from being incorrectly identified as identical during ancestor tree traversal.
 
 ## [v1.6.0] - 2026-04-05

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ UDID="B34FF305-5EA8-412B-943F-1D0371CA17FF"
 axe tap -x 100 -y 200 --udid $UDID
 axe tap --id "Safari" --udid $UDID
 axe tap --label "Safari" --udid $UDID
+axe tap --label "Weather Alerts" --udid $UDID  # Auto-uses physical touch for matched switches/toggles
+axe tap -x 320 -y 780 --tap-style physical --udid $UDID  # Force physical touch for coordinate taps
 axe type 'Hello World!' --udid $UDID
 axe swipe --start-x 100 --start-y 300 --end-x 300 --end-y 100 --udid $UDID
 axe button home --udid $UDID
@@ -189,6 +191,9 @@ axe tap -x 100 -y 200 --pre-delay 1.0 --post-delay 0.5 --udid SIMULATOR_UDID
 # Tap by accessibility element (uses describe-ui accessibility tree)
 axe tap --id "Safari" --udid SIMULATOR_UDID
 axe tap --label "Safari" --udid SIMULATOR_UDID
+axe tap --label "Weather Alerts" --udid SIMULATOR_UDID  # Switches/toggles use their activation point and physical touch when matched
+axe tap --label "Submit" --tap-style simulator --udid SIMULATOR_UDID  # Force FBSimulator tapAt
+axe tap -x 320 -y 780 --tap-style physical --udid SIMULATOR_UDID  # Force touch down/up
 
 # Swipe gestures
 axe swipe --start-x 100 --start-y 300 --end-x 300 --end-y 100 --udid SIMULATOR_UDID
@@ -276,6 +281,10 @@ axe batch --udid SIMULATOR_UDID \
   --step "tap --id SearchField" \
   --step "type 'hello world'" \
   --step "key 40"
+
+# Toggle a switch by its label
+axe batch --udid SIMULATOR_UDID \
+  --step "tap --label 'Weather Alerts'"
 
 # Add explicit timing between steps
 axe batch --udid SIMULATOR_UDID \

--- a/Skills/CLI/axe/SKILL.md
+++ b/Skills/CLI/axe/SKILL.md
@@ -7,7 +7,7 @@ description: Provides agent-ready AXe CLI usage guidance for iOS Simulator autom
 1. Identify simulator UDID target first (`axe list-simulators`).
 2. Simulator-interaction AXe commands require `--udid <UDID>`. Commands like `list-simulators` and `init` do not.
 3. Run `axe describe-ui --udid <UDID>` to inspect the full current screen. Use `axe describe-ui --point <X,Y> --udid <UDID>` to inspect the element at a specific coordinate. Use the output to discover available `--id` and `--label` values for selector taps, and to confirm coordinates for coordinate-based taps.
-4. Prefer selector taps (`tap --id` / `tap --label`) over raw coordinates. Selectors are resilient to layout changes, work across device sizes, and support element waiting (`--wait-timeout`) in batch flows.
+4. Prefer selector taps (`tap --id` / `tap --label`) over raw coordinates. Selectors are resilient to layout changes, work across device sizes, and support element waiting (`--wait-timeout`) in batch flows. For UIKit `UISwitch` and SwiftUI `Toggle` rows, selector taps activate the contained switch/toggle when the match contains exactly one such control. Default tap style is `automatic`: switches/toggles use physical touch down/up, while normal taps use simulator `tapAt`.
 
 ## Step 2: Choose the right command
 
@@ -17,6 +17,8 @@ Common examples:
 ```bash
 axe tap --id <identifier> --udid <UDID>
 axe tap --label <text> --udid <UDID>
+axe tap --label 'Weather Alerts' --udid <UDID>
+axe tap -x <X> -y <Y> --tap-style physical --udid <UDID>
 axe tap -x <X> -y <Y> --udid <UDID>
 axe type 'text' --udid <UDID>
 axe describe-ui --udid <UDID>
@@ -53,6 +55,7 @@ HID commands (`tap`, `swipe`, `type`, `key`, etc.) are fire-and-forget — AXe c
 - Use `--ax-cache perStep` when *not* using `--wait-timeout` but the UI still changes between steps — this ensures each selector tap gets a fresh accessibility snapshot rather than a stale cached one.
 - Insert explicit `sleep <seconds>` steps when coordinate-based taps need the UI to be stable (selectors with `--wait-timeout` are preferred over sleep where possible).
 - Keep batch output quiet by default. Add `--verbose` only when troubleshooting.
+- Selector taps in batch share direct `tap` semantics, including switch/toggle activation-point handling and `--tap-style automatic` behavior. Use batch-level `--tap-style physical|simulator` as the default for tap steps, or step-level `tap --tap-style ...` to override one step.
 - If `tap --label` reports multiple matches and no `AXUniqueId` values are exposed, fall back to `tap -x/-y` for that step.
 
 Key rules:

--- a/Skills/CLI/axe/references/batch-reference.md
+++ b/Skills/CLI/axe/references/batch-reference.md
@@ -23,6 +23,7 @@ Use this reference when generating or reviewing `axe batch` commands.
 - `--ax-cache perBatch|perStep|none`: selector tap AX snapshot reuse policy.
 - `--type-submission chunked|composite`: submission mode for `type` steps.
 - `--type-chunk-size <n>`: chunk size when using chunked submission.
+- `--tap-style automatic|simulator|physical`: default tap event style for tap steps.
 - `--wait-timeout <seconds>`: maximum seconds to poll for selector-based elements before failing (0 = no waiting, default).
 - `--poll-interval <seconds>`: seconds between accessibility tree polls when `--wait-timeout` is active (default 0.25).
 - `--verbose`: enable detailed stderr logs for troubleshooting (default quiet output).
@@ -92,4 +93,12 @@ axe batch --udid SIMULATOR_UDID \
 
 The second step polls for up to 5 seconds for `WelcomeMessage` to appear after the login tap triggers navigation.
 
-If label selectors are ambiguous and AXe reports no `AXUniqueId` values for matches, switch that step to coordinates (`tap -x/-y`).
+## Example: toggling a setting switch
+```bash
+axe batch --udid SIMULATOR_UDID \
+  --step "tap --label 'Weather Alerts'"
+```
+
+Batch selector taps share direct `axe tap` behavior. If the matched row or label contains exactly one UIKit `UISwitch` or SwiftUI `Toggle`/switch control, AXe taps that control's activation point. With default `--tap-style automatic`, switch/toggle activations use physical touch down/up and normal taps use simulator `tapAt`.
+
+If label selectors are ambiguous and AXe reports no `AXUniqueId` values for matches, switch that step to coordinates (`tap -x/-y`). For coordinate taps that need physical touch, use `tap -x/-y --tap-style physical` or batch-level `--tap-style physical`.

--- a/Skills/CLI/axe/references/cli-quick-reference.md
+++ b/Skills/CLI/axe/references/cli-quick-reference.md
@@ -21,6 +21,9 @@ axe tap --id "SearchField" --udid <UDID>
 
 # By accessibility label
 axe tap --label "Safari" --udid <UDID>
+axe tap --label "Weather Alerts" --udid <UDID>  # Auto physical touch for switches/toggles
+axe tap --label "Submit" --tap-style simulator --udid <UDID>
+axe tap -x 320 -y 780 --tap-style physical --udid <UDID>
 
 # With timing
 axe tap -x 100 -y 200 --pre-delay 1.0 --post-delay 0.5 --udid <UDID>
@@ -158,6 +161,7 @@ axe batch --udid <UDID> \
   --ax-cache perStep \
   --type-submission chunked \
   --type-chunk-size 150 \
+  --tap-style automatic \
   --step "tap --label Settings" \
   --step "sleep 0.5" \
   --step "tap --id SaveButton"
@@ -167,6 +171,10 @@ axe batch --udid <UDID> \
   --wait-timeout 5 \
   --step "tap --id LoginButton" \
   --step "tap --id WelcomeMessage"
+
+# Toggle a setting switch by label
+axe batch --udid <UDID> \
+  --step "tap --label 'Weather Alerts'"
 ```
 
 See `batch-reference.md` for full batch semantics.
@@ -214,6 +222,8 @@ axe stream-video --udid <UDID> --fps 30 --format ffmpeg | \
 
 ## Best practices
 - Prefer `--id` / `--label` taps over coordinates for resilience.
+- Selector taps activate a contained UIKit `UISwitch` or SwiftUI `Toggle` when the matched row or label contains exactly one switch/toggle.
+- Default `--tap-style automatic` uses physical touch for matched switches/toggles and simulator `tapAt` for normal taps; use `--tap-style physical|simulator` to override.
 - Use single quotes for inline text to avoid shell expansion.
 - Use `--stdin` or `--file` when input contains shell-sensitive characters.
 - Keep verification (`describe-ui`, `screenshot`) separate from execution.

--- a/Sources/AXe/Commands/Batch.swift
+++ b/Sources/AXe/Commands/Batch.swift
@@ -42,6 +42,9 @@ struct Batch: AsyncParsableCommand {
     @Option(name: .customLong("type-chunk-size"), help: "Maximum HID events per chunk when type-submission is chunked.")
     var typeChunkSize: Int = 200
 
+    @Option(name: .customLong("tap-style"), help: "Default tap event style for tap steps: automatic uses physical touch for switches/toggles and simulator tap for other targets; simulator always uses FBSimulator tapAt; physical uses touch down/up.")
+    var tapStyle: TapStyle = .automatic
+
     @Flag(name: .customLong("continue-on-error"), help: "Continue executing later steps even if one step fails.")
     var continueOnError: Bool = false
 
@@ -91,6 +94,7 @@ struct Batch: AsyncParsableCommand {
                 axCachePolicy: axCachePolicy,
                 typeSubmissionMode: typeSubmissionMode,
                 typeChunkSize: typeChunkSize,
+                tapStyle: tapStyle,
                 waitTimeout: waitTimeout,
                 pollInterval: pollInterval
             )

--- a/Sources/AXe/Commands/Tap.swift
+++ b/Sources/AXe/Commands/Tap.swift
@@ -5,7 +5,7 @@ import FBSimulatorControl
 
 struct Tap: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        abstract: "Tap on a specific point on the screen, or locate an element by accessibility and tap its center."
+        abstract: "Tap a point on the screen, or locate an element by accessibility and tap its activation point."
     )
 
     @Option(name: .customShort("x"), help: "The X coordinate of the point to tap.")
@@ -14,13 +14,13 @@ struct Tap: AsyncParsableCommand {
     @Option(name: .customShort("y"), help: "The Y coordinate of the point to tap.")
     var pointY: Double?
 
-    @Option(name: [.customLong("id")], help: "Tap the center of the element matching AXUniqueId (accessibilityIdentifier). Ignored if -x and -y are provided.")
+    @Option(name: [.customLong("id")], help: "Tap the activation point of the element matching AXUniqueId (accessibilityIdentifier). Ignored if -x and -y are provided.")
     var elementID: String?
 
-    @Option(name: [.customLong("label")], help: "Tap the center of the element matching AXLabel (accessibilityLabel). Ignored if -x and -y are provided.")
+    @Option(name: [.customLong("label")], help: "Tap the activation point of the element matching AXLabel (accessibilityLabel). Ignored if -x and -y are provided.")
     var elementLabel: String?
 
-    @Option(name: [.customLong("value")], help: "Tap the center of the element matching AXValue (the current value of a control). Ignored if -x and -y are provided.")
+    @Option(name: [.customLong("value")], help: "Tap the activation point of the element matching AXValue (the current value of a control). Ignored if -x and -y are provided.")
     var elementValue: String?
 
     @Option(name: [.customLong("element-type")], help: "Filter matches to elements of this accessibility type (e.g. Button, TextField, Switch). Narrows --id/--label/--value results when multiple elements match.")

--- a/Sources/AXe/Commands/Tap.swift
+++ b/Sources/AXe/Commands/Tap.swift
@@ -32,6 +32,9 @@ struct Tap: AsyncParsableCommand {
     @Option(name: .customLong("post-delay"), help: "Delay after tapping in seconds.")
     var postDelay: Double?
 
+    @Option(name: .customLong("tap-style"), help: "Tap event style: automatic uses physical touch for switches/toggles and simulator tap for other targets; simulator always uses FBSimulator tapAt; physical uses touch down/up.")
+    var tapStyle: TapStyle?
+
     @Option(name: .customLong("wait-timeout"), help: "Maximum seconds to poll for the element before failing (0 = no waiting, default). Only applies to --id/--label/--value targeting.")
     var waitTimeout: Double = 0
 
@@ -99,11 +102,11 @@ struct Tap: AsyncParsableCommand {
 
         try await performGlobalSetup(logger: logger)
 
-        let logicalPoint: (x: Double, y: Double)
+        let resolution: TapResolution
         let resolvedDescription: String
 
         if let pointX, let pointY {
-            logicalPoint = (x: pointX, y: pointY)
+            resolution = TapResolution(point: (x: pointX, y: pointY), isSwitchLikeControl: false)
             resolvedDescription = "(\(pointX), \(pointY))"
         } else {
             let query: AccessibilityQuery
@@ -118,7 +121,7 @@ struct Tap: AsyncParsableCommand {
             }
 
             do {
-                logicalPoint = try await AccessibilityPoller.resolveWithPolling(
+                resolution = try await AccessibilityPoller.resolveWithPolling(
                     query: query,
                     simulatorUDID: simulatorUDID,
                     waitTimeout: waitTimeout,
@@ -131,35 +134,56 @@ struct Tap: AsyncParsableCommand {
                 throw error
             }
 
-            resolvedDescription = "center of matched element at (\(logicalPoint.x), \(logicalPoint.y))"
+            resolvedDescription = "resolved tap point at (\(resolution.point.x), \(resolution.point.y))"
         }
 
         logger.info().log("Tapping at \(resolvedDescription)")
 
-        let resolvedPoint = try await OrientationAwareCoordinates.translate(
-            point: logicalPoint,
+        let physicalPoint = try await OrientationAwareCoordinates.translate(
+            point: resolution.point,
             for: simulatorUDID,
             logger: logger
         )
 
-        var events: [FBSimulatorHIDEvent] = []
-        if let preDelay = preDelay, preDelay > 0 {
-            logger.info().log("Pre-delay: \(preDelay)s")
-            events.append(.delay(preDelay))
+        switch resolvedTapStyle(for: resolution) {
+        case .physical:
+            try await HIDInteractor.performPhysicalTap(
+                at: physicalPoint,
+                preDelay: preDelay,
+                postDelay: postDelay,
+                for: simulatorUDID,
+                logger: logger
+            )
+        case .simulator:
+            var events: [FBSimulatorHIDEvent] = []
+            if let preDelay, preDelay > 0 {
+                logger.info().log("Pre-delay: \(preDelay)s")
+                events.append(.delay(preDelay))
+            }
+            events.append(.tapAt(x: physicalPoint.x, y: physicalPoint.y))
+            if let postDelay, postDelay > 0 {
+                logger.info().log("Post-delay: \(postDelay)s")
+                events.append(.delay(postDelay))
+            }
+
+            let finalEvent = events.count == 1 ? events[0] : FBSimulatorHIDEvent(events: events)
+            try await HIDInteractor.performHIDEvent(finalEvent, for: simulatorUDID, logger: logger)
+        case .automatic:
+            throw CLIError(errorDescription: "Unexpected tap style resolution.")
         }
-
-        events.append(.tapAt(x: resolvedPoint.x, y: resolvedPoint.y))
-
-        if let postDelay = postDelay, postDelay > 0 {
-            logger.info().log("Post-delay: \(postDelay)s")
-            events.append(.delay(postDelay))
-        }
-
-        let finalEvent = events.count == 1 ? events[0] : FBSimulatorHIDEvent(events: events)
-
-        try await HIDInteractor.performHIDEvent(finalEvent, for: simulatorUDID, logger: logger)
 
         logger.info().log("Tap completed successfully")
         print("✓ Tap at \(resolvedDescription) completed successfully")
+    }
+
+    private func resolvedTapStyle(for resolution: TapResolution) -> TapStyle {
+        switch tapStyle ?? .automatic {
+        case .automatic:
+            return resolution.isSwitchLikeControl ? .physical : .simulator
+        case .simulator:
+            return .simulator
+        case .physical:
+            return .physical
+        }
     }
 }

--- a/Sources/AXe/Commands/Touch.swift
+++ b/Sources/AXe/Commands/Touch.swift
@@ -81,7 +81,7 @@ struct Touch: AsyncParsableCommand {
         if touchDown && touchUp {
             // Send down and up as separate HID submissions so iOS recognizers
             // observe a real hold duration for long-press gestures.
-            let touchDelay = delay ?? 0.1
+            let touchDelay = delay ?? TapTiming.defaultHoldDuration
 
             logger.info().log("Touch down")
             try await HIDInteractor

--- a/Sources/AXe/Resources/skills/axe/SKILL.md
+++ b/Sources/AXe/Resources/skills/axe/SKILL.md
@@ -7,7 +7,7 @@ description: Provides agent-ready AXe CLI usage guidance for iOS Simulator autom
 1. Identify simulator UDID target first (`axe list-simulators`).
 2. Simulator-interaction AXe commands require `--udid <UDID>`. Commands like `list-simulators` and `init` do not.
 3. Run `axe describe-ui --udid <UDID>` to inspect the full current screen. Use `axe describe-ui --point <X,Y> --udid <UDID>` to inspect the element at a specific coordinate. Use the output to discover available `--id` and `--label` values for selector taps, and to confirm coordinates for coordinate-based taps.
-4. Prefer selector taps (`tap --id` / `tap --label`) over raw coordinates. Selectors are resilient to layout changes, work across device sizes, and support element waiting (`--wait-timeout`) in batch flows.
+4. Prefer selector taps (`tap --id` / `tap --label`) over raw coordinates. Selectors are resilient to layout changes, work across device sizes, and support element waiting (`--wait-timeout`) in batch flows. For UIKit `UISwitch` and SwiftUI `Toggle` rows, selector taps activate the contained switch/toggle when the match contains exactly one such control. Default tap style is `automatic`: switches/toggles use physical touch down/up, while normal taps use simulator `tapAt`.
 
 ## Step 2: Choose the right command
 
@@ -17,6 +17,8 @@ Common examples:
 ```bash
 axe tap --id <identifier> --udid <UDID>
 axe tap --label <text> --udid <UDID>
+axe tap --label 'Weather Alerts' --udid <UDID>
+axe tap -x <X> -y <Y> --tap-style physical --udid <UDID>
 axe tap -x <X> -y <Y> --udid <UDID>
 axe type 'text' --udid <UDID>
 axe describe-ui --udid <UDID>
@@ -53,6 +55,7 @@ HID commands (`tap`, `swipe`, `type`, `key`, etc.) are fire-and-forget — AXe c
 - Use `--ax-cache perStep` when *not* using `--wait-timeout` but the UI still changes between steps — this ensures each selector tap gets a fresh accessibility snapshot rather than a stale cached one.
 - Insert explicit `sleep <seconds>` steps when coordinate-based taps need the UI to be stable (selectors with `--wait-timeout` are preferred over sleep where possible).
 - Keep batch output quiet by default. Add `--verbose` only when troubleshooting.
+- Selector taps in batch share direct `tap` semantics, including switch/toggle activation-point handling and `--tap-style automatic` behavior. Use batch-level `--tap-style physical|simulator` as the default for tap steps, or step-level `tap --tap-style ...` to override one step.
 - If `tap --label` reports multiple matches and no `AXUniqueId` values are exposed, fall back to `tap -x/-y` for that step.
 
 Key rules:

--- a/Sources/AXe/Types/TapStyle.swift
+++ b/Sources/AXe/Types/TapStyle.swift
@@ -1,0 +1,17 @@
+import ArgumentParser
+import Foundation
+
+enum TapStyle: String, CaseIterable, ExpressibleByArgument {
+    case automatic
+    case simulator
+    case physical
+}
+
+struct TapResolution {
+    let point: (x: Double, y: Double)
+    let isSwitchLikeControl: Bool
+}
+
+enum TapTiming {
+    static let defaultHoldDuration: TimeInterval = 0.1
+}

--- a/Sources/AXe/Utilities/AccessibilityElement.swift
+++ b/Sources/AXe/Utilities/AccessibilityElement.swift
@@ -14,47 +14,87 @@ struct AccessibilityElement: Decodable {
         "Switch",
         "Tab",
         "TabBarButton",
-        "TextField"
+        "TextField",
+        "Toggle"
     ]
+
     struct Frame: Decodable {
         let x: Double
         let y: Double
         let width: Double
         let height: Double
     }
-    
+
     let type: String?
     let frame: Frame?
     let children: [AccessibilityElement]?
+    let role: String?
+    let roleDescription: String?
+    let subrole: String?
 
     let AXLabel: String?
     let AXUniqueId: String?
+    let AXIdentifier: String?
     let AXValue: String?
 
+    enum CodingKeys: String, CodingKey {
+        case type
+        case frame
+        case children
+        case role
+        case roleDescription = "role_description"
+        case subrole
+        case AXLabel
+        case AXUniqueId
+        case AXIdentifier
+        case AXValue
+    }
+
     var normalizedLabel: String? {
-        AXLabel?.trimmingCharacters(in: .whitespacesAndNewlines)
+        trimmed(AXLabel)
     }
 
     var normalizedUniqueId: String? {
-        AXUniqueId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        trimmed(AXUniqueId) ?? trimmed(AXIdentifier)
     }
 
     var normalizedValue: String? {
-        AXValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+        trimmed(AXValue)
     }
 
     var isActionable: Bool {
-        guard let type else {
-            return false
-        }
-        return Self.actionableTypes.contains(type)
+        isSwitchLikeControl || type.map(Self.actionableTypes.contains) == true
     }
-    
+
+    var isSwitchLikeControl: Bool {
+        if type == "Switch" || type == "Toggle" {
+            return true
+        }
+        if role == "AXSwitch" || subrole == "AXSwitch" {
+            return true
+        }
+        if let roleDescription = trimmed(roleDescription)?.lowercased(),
+           roleDescription.contains("switch") || roleDescription.contains("toggle") {
+            return true
+        }
+        return false
+    }
+
     func flattened() -> [AccessibilityElement] {
         var result: [AccessibilityElement] = [self]
         if let children {
             result.append(contentsOf: children.flatMap { $0.flattened() })
         }
         return result
+    }
+
+    func switchLikeDescendantsIncludingSelf() -> [AccessibilityElement] {
+        flattened().filter(\.isSwitchLikeControl)
+    }
+
+    private func trimmed(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue.isEmpty ? nil : trimmedValue
     }
 }

--- a/Sources/AXe/Utilities/AccessibilityElement.swift
+++ b/Sources/AXe/Utilities/AccessibilityElement.swift
@@ -55,7 +55,11 @@ struct AccessibilityElement: Decodable {
     }
 
     var normalizedUniqueId: String? {
-        trimmed(AXUniqueId) ?? trimmed(AXIdentifier)
+        normalizedStableUniqueId ?? trimmed(AXIdentifier)
+    }
+
+    var normalizedStableUniqueId: String? {
+        trimmed(AXUniqueId)
     }
 
     var normalizedValue: String? {

--- a/Sources/AXe/Utilities/AccessibilityPoller.swift
+++ b/Sources/AXe/Utilities/AccessibilityPoller.swift
@@ -10,7 +10,26 @@ struct AccessibilityPoller {
         elementType: String? = nil,
         logger: AxeLogger
     ) async throws -> TapResolution {
-        let roots = try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
+        try await pollForResolution(
+            query: query,
+            waitTimeout: waitTimeout,
+            pollInterval: pollInterval,
+            elementType: elementType,
+            logger: logger
+        ) {
+            try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
+        }
+    }
+
+    static func pollForResolution(
+        query: AccessibilityQuery,
+        waitTimeout: TimeInterval,
+        pollInterval: TimeInterval,
+        elementType: String?,
+        logger: AxeLogger,
+        rootsFetcher: () async throws -> [AccessibilityElement]
+    ) async throws -> TapResolution {
+        let roots = try await rootsFetcher()
         do {
             return try AccessibilityTargetResolver.resolveTap(roots: roots, query: query, elementType: elementType)
         } catch let error as ElementResolutionError where error.isNotFound && waitTimeout > 0 {
@@ -22,7 +41,7 @@ struct AccessibilityPoller {
                 logger.info().log("Element not found, retrying in \(pollInterval)s…")
                 try await Task.sleep(for: .seconds(pollInterval))
 
-                let freshRoots = try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
+                let freshRoots = try await rootsFetcher()
                 do {
                     return try AccessibilityTargetResolver.resolveTap(roots: freshRoots, query: query, elementType: elementType)
                 } catch let retryError as ElementResolutionError where retryError.isNotFound {

--- a/Sources/AXe/Utilities/AccessibilityPoller.swift
+++ b/Sources/AXe/Utilities/AccessibilityPoller.swift
@@ -9,10 +9,10 @@ struct AccessibilityPoller {
         pollInterval: TimeInterval,
         elementType: String? = nil,
         logger: AxeLogger
-    ) async throws -> (x: Double, y: Double) {
+    ) async throws -> TapResolution {
         let roots = try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
         do {
-            return try AccessibilityTargetResolver.resolveCenterPoint(roots: roots, query: query, elementType: elementType)
+            return try AccessibilityTargetResolver.resolveTap(roots: roots, query: query, elementType: elementType)
         } catch let error as ElementResolutionError where error.isNotFound && waitTimeout > 0 {
             let clock = ContinuousClock()
             let deadline = clock.now + .seconds(waitTimeout)
@@ -24,7 +24,7 @@ struct AccessibilityPoller {
 
                 let freshRoots = try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
                 do {
-                    return try AccessibilityTargetResolver.resolveCenterPoint(roots: freshRoots, query: query, elementType: elementType)
+                    return try AccessibilityTargetResolver.resolveTap(roots: freshRoots, query: query, elementType: elementType)
                 } catch let retryError as ElementResolutionError where retryError.isNotFound {
                     lastError = retryError
                     continue

--- a/Sources/AXe/Utilities/AccessibilityTargetResolver.swift
+++ b/Sources/AXe/Utilities/AccessibilityTargetResolver.swift
@@ -4,6 +4,15 @@ enum AccessibilityQuery {
     case id(String)
     case label(String)
     case value(String)
+
+    var allowsSiblingRedirection: Bool {
+        switch self {
+        case .label:
+            return true
+        case .id, .value:
+            return false
+        }
+    }
 }
 
 enum ElementResolutionError: LocalizedError {
@@ -81,7 +90,8 @@ struct AccessibilityTargetResolver {
         let activationElement = try selectActivationElement(
             from: matchedElement,
             roots: roots,
-            selectorDescription: selectorDescription
+            selectorDescription: selectorDescription,
+            allowSiblingRedirection: query.allowsSiblingRedirection
         )
 
         guard let frame = activationElement.frame else {
@@ -157,7 +167,8 @@ struct AccessibilityTargetResolver {
     private static func selectActivationElement(
         from matchedElement: AccessibilityElement,
         roots: [AccessibilityElement],
-        selectorDescription: String
+        selectorDescription: String,
+        allowSiblingRedirection: Bool
     ) throws -> AccessibilityElement {
         if matchedElement.isSwitchLikeControl {
             return matchedElement
@@ -178,7 +189,7 @@ struct AccessibilityTargetResolver {
             return matchedElement
         }
 
-        if let ancestor = nearestAncestor(of: matchedElement, in: roots) {
+        if allowSiblingRedirection, let ancestor = nearestAncestor(of: matchedElement, in: roots) {
             let siblingSwitches = ancestor.switchLikeDescendantsIncludingSelf()
             if siblingSwitches.count == 1 {
                 return siblingSwitches[0]

--- a/Sources/AXe/Utilities/AccessibilityTargetResolver.swift
+++ b/Sources/AXe/Utilities/AccessibilityTargetResolver.swift
@@ -222,10 +222,20 @@ struct AccessibilityTargetResolver {
             return lhsID == rhsID
         }
 
-        return lhs.type == rhs.type
-            && lhs.normalizedLabel == rhs.normalizedLabel
-            && lhs.normalizedValue == rhs.normalizedValue
-            && sameFrame(lhs.frame, rhs.frame)
+        guard lhs.type == rhs.type,
+              lhs.normalizedLabel == rhs.normalizedLabel,
+              lhs.normalizedValue == rhs.normalizedValue,
+              sameFrame(lhs.frame, rhs.frame) else {
+            return false
+        }
+
+        if lhs.normalizedLabel == nil && lhs.normalizedValue == nil {
+            return lhs.role == rhs.role
+                && lhs.roleDescription == rhs.roleDescription
+                && lhs.subrole == rhs.subrole
+        }
+
+        return true
     }
 
     private static func sameFrame(_ lhs: AccessibilityElement.Frame?, _ rhs: AccessibilityElement.Frame?) -> Bool {

--- a/Sources/AXe/Utilities/AccessibilityTargetResolver.swift
+++ b/Sources/AXe/Utilities/AccessibilityTargetResolver.swift
@@ -10,6 +10,7 @@ enum ElementResolutionError: LocalizedError {
     case notFound(kind: String, value: String)
     case multipleMatches(count: Int, kind: String, value: String, hasUniqueIDs: Bool)
     case invalidFrame(reason: String)
+    case multipleSwitchDescendants(count: Int, selectorDescription: String)
 
     var errorDescription: String? {
         let tip = AccessibilityTargetResolver.describeUITip
@@ -23,6 +24,8 @@ enum ElementResolutionError: LocalizedError {
             return "Multiple (\(count)) accessibility elements matched \(kind) '\(value)', and none of the matches expose AXUniqueId on this screen. Use coordinates for this step (tap -x/-y) or target a more specific screen/state. \(tip)"
         case .invalidFrame(let reason):
             return "\(reason) \(tip)"
+        case .multipleSwitchDescendants(let count, let selectorDescription):
+            return "Matched element for \(selectorDescription) contains multiple (\(count)) switch/toggle controls. Target the switch more specifically with --id, --element-type Switch, or coordinates. \(tip)"
         }
     }
 
@@ -35,11 +38,19 @@ enum ElementResolutionError: LocalizedError {
 struct AccessibilityTargetResolver {
     static let describeUITip = "Make sure the app is on the expected screen, then run `axe describe-ui --udid <SIMULATOR_UDID>` and prefer --id when available."
 
-    static func resolveCenterPoint(
+    static func resolveTapPoint(
         roots: [AccessibilityElement],
         query: AccessibilityQuery,
         elementType: String? = nil
     ) throws -> (x: Double, y: Double) {
+        try resolveTap(roots: roots, query: query, elementType: elementType).point
+    }
+
+    static func resolveTap(
+        roots: [AccessibilityElement],
+        query: AccessibilityQuery,
+        elementType: String? = nil
+    ) throws -> TapResolution {
         var allElements = roots.flatMap { $0.flattened() }
 
         if let elementType {
@@ -47,32 +58,57 @@ struct AccessibilityTargetResolver {
         }
 
         let matchedElement: AccessibilityElement
+        let selectorDescription: String
 
         switch query {
         case .id(let rawValue):
             let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
             let matches = allElements.filter { $0.normalizedUniqueId == value }
             matchedElement = try selectUniqueMatch(matches, kind: "--id", value: rawValue)
+            selectorDescription = "--id '\(rawValue)'"
         case .label(let rawValue):
             let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
             let matches = allElements.filter { $0.normalizedLabel == value }
             matchedElement = try selectBestLabelMatch(matches, value: rawValue)
+            selectorDescription = "--label '\(rawValue)'"
         case .value(let rawValue):
             let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
             let matches = allElements.filter { $0.normalizedValue == value }
             matchedElement = try selectBestLabelMatch(matches, kind: "--value", value: rawValue)
+            selectorDescription = "--value '\(rawValue)'"
         }
 
-        guard let frame = matchedElement.frame else {
+        let activationElement = try selectActivationElement(
+            from: matchedElement,
+            roots: roots,
+            selectorDescription: selectorDescription
+        )
+
+        guard let frame = activationElement.frame else {
             throw ElementResolutionError.invalidFrame(reason: "Matched element has no frame.")
         }
         guard frame.width > 0, frame.height > 0 else {
             throw ElementResolutionError.invalidFrame(reason: "Matched element has an invalid frame size (\(frame.width)x\(frame.height)).")
         }
 
-        let centerX = frame.x + (frame.width / 2.0)
+        return TapResolution(
+            point: activationPoint(for: activationElement, frame: frame),
+            isSwitchLikeControl: activationElement.isSwitchLikeControl
+        )
+    }
+
+    private static func activationPoint(
+        for element: AccessibilityElement,
+        frame: AccessibilityElement.Frame
+    ) -> (x: Double, y: Double) {
         let centerY = frame.y + (frame.height / 2.0)
-        return (x: centerX, y: centerY)
+
+        if element.isSwitchLikeControl, frame.width > 100 {
+            let switchTrailingActivationInset = 31.0
+            return (x: frame.x + frame.width - switchTrailingActivationInset, y: centerY)
+        }
+
+        return (x: frame.x + (frame.width / 2.0), y: centerY)
     }
 
     private static func selectUniqueMatch(
@@ -98,6 +134,14 @@ struct AccessibilityTargetResolver {
         kind: String = "--label",
         value: String
     ) throws -> AccessibilityElement {
+        let switchLikeMatches = matches.filter(\.isSwitchLikeControl)
+        if switchLikeMatches.count == 1 {
+            return switchLikeMatches[0]
+        }
+        if switchLikeMatches.count > 1 {
+            return try selectUniqueMatch(switchLikeMatches, kind: kind, value: value)
+        }
+
         let actionableMatches = matches.filter(\.isActionable)
         if actionableMatches.count == 1 {
             return actionableMatches[0]
@@ -109,5 +153,82 @@ struct AccessibilityTargetResolver {
 
         return try selectUniqueMatch(matches, kind: kind, value: value)
     }
-}
 
+    private static func selectActivationElement(
+        from matchedElement: AccessibilityElement,
+        roots: [AccessibilityElement],
+        selectorDescription: String
+    ) throws -> AccessibilityElement {
+        if matchedElement.isSwitchLikeControl {
+            return matchedElement
+        }
+
+        let switchDescendants = matchedElement.switchLikeDescendantsIncludingSelf()
+        if !switchDescendants.isEmpty {
+            guard switchDescendants.count == 1 else {
+                throw ElementResolutionError.multipleSwitchDescendants(
+                    count: switchDescendants.count,
+                    selectorDescription: selectorDescription
+                )
+            }
+            return switchDescendants[0]
+        }
+
+        if let ancestor = nearestAncestor(of: matchedElement, in: roots) {
+            let siblingSwitches = ancestor.switchLikeDescendantsIncludingSelf()
+            if siblingSwitches.count == 1 {
+                return siblingSwitches[0]
+            }
+        }
+
+        return matchedElement
+    }
+
+    private static func nearestAncestor(
+        of matchedElement: AccessibilityElement,
+        in roots: [AccessibilityElement]
+    ) -> AccessibilityElement? {
+        for root in roots {
+            if let ancestor = nearestAncestor(of: matchedElement, in: root, parent: nil) {
+                return ancestor
+            }
+        }
+        return nil
+    }
+
+    private static func nearestAncestor(
+        of matchedElement: AccessibilityElement,
+        in currentElement: AccessibilityElement,
+        parent: AccessibilityElement?
+    ) -> AccessibilityElement? {
+        if sameElement(currentElement, matchedElement) {
+            return parent
+        }
+
+        for child in currentElement.children ?? [] {
+            if let ancestor = nearestAncestor(of: matchedElement, in: child, parent: currentElement) {
+                return ancestor
+            }
+        }
+        return nil
+    }
+
+    private static func sameElement(_ lhs: AccessibilityElement, _ rhs: AccessibilityElement) -> Bool {
+        if let lhsID = lhs.normalizedUniqueId, let rhsID = rhs.normalizedUniqueId {
+            return lhsID == rhsID
+        }
+
+        return lhs.type == rhs.type
+            && lhs.normalizedLabel == rhs.normalizedLabel
+            && lhs.normalizedValue == rhs.normalizedValue
+            && sameFrame(lhs.frame, rhs.frame)
+    }
+
+    private static func sameFrame(_ lhs: AccessibilityElement.Frame?, _ rhs: AccessibilityElement.Frame?) -> Bool {
+        guard let lhs, let rhs else { return lhs == nil && rhs == nil }
+        return lhs.x == rhs.x
+            && lhs.y == rhs.y
+            && lhs.width == rhs.width
+            && lhs.height == rhs.height
+    }
+}

--- a/Sources/AXe/Utilities/AccessibilityTargetResolver.swift
+++ b/Sources/AXe/Utilities/AccessibilityTargetResolver.swift
@@ -34,7 +34,7 @@ enum ElementResolutionError: LocalizedError {
         case .invalidFrame(let reason):
             return "\(reason) \(tip)"
         case .multipleSwitchDescendants(let count, let selectorDescription):
-            return "Matched element for \(selectorDescription) contains multiple (\(count)) switch/toggle controls. Target the switch more specifically with --id, --element-type Switch, or coordinates. \(tip)"
+            return "Matched element for \(selectorDescription) contains multiple (\(count)) switch/toggle controls. Target the switch more specifically with --id when available, or use coordinates. Use --element-type only when describe-ui reports a specific target type like Switch or Toggle. \(tip)"
         }
     }
 
@@ -46,6 +46,9 @@ enum ElementResolutionError: LocalizedError {
 
 struct AccessibilityTargetResolver {
     static let describeUITip = "Make sure the app is on the expected screen, then run `axe describe-ui --udid <SIMULATOR_UDID>` and prefer --id when available."
+
+    private static let wideSwitchActivationWidthThreshold = 100.0
+    private static let switchTrailingActivationInset = 31.0
 
     static func resolveTapPoint(
         roots: [AccessibilityElement],
@@ -113,8 +116,7 @@ struct AccessibilityTargetResolver {
     ) -> (x: Double, y: Double) {
         let centerY = frame.y + (frame.height / 2.0)
 
-        if element.isSwitchLikeControl, frame.width > 100 {
-            let switchTrailingActivationInset = 31.0
+        if element.isSwitchLikeControl, frame.width > wideSwitchActivationWidthThreshold {
             return (x: frame.x + frame.width - switchTrailingActivationInset, y: centerY)
         }
 
@@ -190,13 +192,17 @@ struct AccessibilityTargetResolver {
         }
 
         if allowSiblingRedirection, let ancestor = nearestAncestor(of: matchedElement, in: roots) {
-            let siblingSwitches = ancestor.switchLikeDescendantsIncludingSelf()
+            let siblingSwitches = directSwitchLikeChildren(of: ancestor)
             if siblingSwitches.count == 1 {
                 return siblingSwitches[0]
             }
         }
 
         return matchedElement
+    }
+
+    private static func directSwitchLikeChildren(of element: AccessibilityElement) -> [AccessibilityElement] {
+        element.children?.filter(\.isSwitchLikeControl) ?? []
     }
 
     private static func nearestAncestor(
@@ -229,7 +235,7 @@ struct AccessibilityTargetResolver {
     }
 
     private static func sameElement(_ lhs: AccessibilityElement, _ rhs: AccessibilityElement) -> Bool {
-        if let lhsID = lhs.normalizedUniqueId, let rhsID = rhs.normalizedUniqueId {
+        if let lhsID = lhs.normalizedStableUniqueId, let rhsID = rhs.normalizedStableUniqueId {
             return lhsID == rhsID
         }
 

--- a/Sources/AXe/Utilities/AccessibilityTargetResolver.swift
+++ b/Sources/AXe/Utilities/AccessibilityTargetResolver.swift
@@ -174,6 +174,10 @@ struct AccessibilityTargetResolver {
             return switchDescendants[0]
         }
 
+        if matchedElement.isActionable {
+            return matchedElement
+        }
+
         if let ancestor = nearestAncestor(of: matchedElement, in: roots) {
             let siblingSwitches = ancestor.switchLikeDescendantsIncludingSelf()
             if siblingSwitches.count == 1 {

--- a/Sources/AXe/Utilities/Batch/BatchContext.swift
+++ b/Sources/AXe/Utilities/Batch/BatchContext.swift
@@ -18,6 +18,7 @@ final class BatchContext {
     let axCachePolicy: AXCachePolicy
     let typeSubmissionMode: TypeSubmissionMode
     let typeChunkSize: Int
+    let tapStyle: TapStyle
     let waitTimeout: TimeInterval
     let pollInterval: TimeInterval
 
@@ -28,6 +29,7 @@ final class BatchContext {
         axCachePolicy: AXCachePolicy,
         typeSubmissionMode: TypeSubmissionMode,
         typeChunkSize: Int,
+        tapStyle: TapStyle = .automatic,
         waitTimeout: TimeInterval = 0,
         pollInterval: TimeInterval = 0.25
     ) {
@@ -35,6 +37,7 @@ final class BatchContext {
         self.axCachePolicy = axCachePolicy
         self.typeSubmissionMode = typeSubmissionMode
         self.typeChunkSize = typeChunkSize
+        self.tapStyle = tapStyle
         self.waitTimeout = waitTimeout
         self.pollInterval = pollInterval
     }

--- a/Sources/AXe/Utilities/Batch/BatchPlan.swift
+++ b/Sources/AXe/Utilities/Batch/BatchPlan.swift
@@ -5,6 +5,7 @@ enum BatchPrimitive {
     case hidMergeable(FBSimulatorHIDEvent)
     case hidBarrier(FBSimulatorHIDEvent)
     case hostSleep(TimeInterval)
+    case physicalTap(point: (x: Double, y: Double), preDelay: Double?, postDelay: Double?)
 }
 
 struct BatchPlan {

--- a/Sources/AXe/Utilities/Batch/BatchPlanRunner.swift
+++ b/Sources/AXe/Utilities/Batch/BatchPlanRunner.swift
@@ -28,6 +28,15 @@ struct BatchPlanRunner {
                 guard seconds > 0 else { continue }
 
                 try await Task.sleep(for: .seconds(seconds))
+            case .physicalTap(let point, let preDelay, let postDelay):
+                try await flushPending()
+                try await HIDInteractor.performPhysicalTap(
+                    at: point,
+                    preDelay: preDelay,
+                    postDelay: postDelay,
+                    in: session,
+                    logger: logger
+                )
             }
         }
 

--- a/Sources/AXe/Utilities/Batch/Command+BatchConvertible.swift
+++ b/Sources/AXe/Utilities/Batch/Command+BatchConvertible.swift
@@ -28,11 +28,11 @@ private func resolveBatchTapPoint(
     context: BatchContext,
     elementType: String?,
     logger: AxeLogger
-) async throws -> (point: (x: Double, y: Double), roots: [AccessibilityElement]) {
+) async throws -> (resolution: TapResolution, roots: [AccessibilityElement]) {
     let roots = try await context.accessibilityRoots(logger: logger)
     do {
-        let point = try AccessibilityTargetResolver.resolveCenterPoint(roots: roots, query: query, elementType: elementType)
-        return (point, roots)
+        let resolution = try AccessibilityTargetResolver.resolveTap(roots: roots, query: query, elementType: elementType)
+        return (resolution, roots)
     } catch let error as ElementResolutionError where error.isNotFound && context.waitTimeout > 0 {
         let clock = ContinuousClock()
         let deadline = clock.now + .seconds(context.waitTimeout)
@@ -44,8 +44,8 @@ private func resolveBatchTapPoint(
 
             let freshRoots = try await context.accessibilityRoots(logger: logger, forceRefresh: true)
             do {
-                let point = try AccessibilityTargetResolver.resolveCenterPoint(roots: freshRoots, query: query, elementType: elementType)
-                return (point, freshRoots)
+                let resolution = try AccessibilityTargetResolver.resolveTap(roots: freshRoots, query: query, elementType: elementType)
+                return (resolution, freshRoots)
             } catch let retryError as ElementResolutionError where retryError.isNotFound {
                 lastError = retryError
                 continue
@@ -72,12 +72,24 @@ func parseCommaSeparatedIntsStrict(_ rawValue: String, fieldName: String) throws
 }
 
 extension Tap: BatchConvertible {
+    private func resolvedTapStyle(for resolution: TapResolution, context: BatchContext) -> TapStyle {
+        let requestedStyle = tapStyle ?? context.tapStyle
+        switch requestedStyle {
+        case .automatic:
+            return resolution.isSwitchLikeControl ? .physical : .simulator
+        case .simulator:
+            return .simulator
+        case .physical:
+            return .physical
+        }
+    }
+
     func toBatchPrimitives(context: BatchContext, logger: AxeLogger) async throws -> [BatchPrimitive] {
-        let resolvedPoint: (x: Double, y: Double)
+        let resolution: TapResolution
         let resolvedRoots: [AccessibilityElement]?
 
         if let pointX, let pointY {
-            resolvedPoint = (pointX, pointY)
+            resolution = TapResolution(point: (x: pointX, y: pointY), isSwitchLikeControl: false)
             resolvedRoots = nil
         } else {
             let query: AccessibilityQuery
@@ -97,28 +109,36 @@ extension Tap: BatchConvertible {
                 elementType: elementType,
                 logger: logger
             )
-            resolvedPoint = resolved.point
+            resolution = resolved.resolution
             resolvedRoots = resolved.roots
         }
 
         let physicalPoint: (x: Double, y: Double)
         if let resolvedRoots {
             physicalPoint = try await OrientationAwareCoordinates.translate(
-                point: resolvedPoint,
+                point: resolution.point,
                 roots: resolvedRoots,
                 for: context.simulatorUDID,
                 logger: logger
             )
         } else {
             physicalPoint = try await OrientationAwareCoordinates.translate(
-                point: resolvedPoint,
+                point: resolution.point,
                 for: context.simulatorUDID,
                 logger: logger
             )
         }
 
-        let tapEvent = FBSimulatorHIDEvent.tapAt(x: physicalPoint.x, y: physicalPoint.y)
-        return [.hidMergeable(buildDelayedEvent(preDelay: preDelay, mainEvent: tapEvent, postDelay: postDelay))]
+        let style = resolvedTapStyle(for: resolution, context: context)
+        switch style {
+        case .physical:
+            return [.physicalTap(point: physicalPoint, preDelay: preDelay, postDelay: postDelay)]
+        case .simulator:
+            let tapEvent = FBSimulatorHIDEvent.tapAt(x: physicalPoint.x, y: physicalPoint.y)
+            return [.hidMergeable(buildDelayedEvent(preDelay: preDelay, mainEvent: tapEvent, postDelay: postDelay))]
+        case .automatic:
+            throw CLIError(errorDescription: "Unexpected tap style resolution.")
+        }
     }
 }
 
@@ -179,7 +199,7 @@ extension Touch: BatchConvertible {
         let touchUpEvent = FBSimulatorHIDEvent.touchUpAt(x: physicalPoint.x, y: physicalPoint.y)
 
         if touchDown && touchUp {
-            let holdDelay = delay ?? 0.1
+            let holdDelay = delay ?? TapTiming.defaultHoldDuration
             return [
                 .hidBarrier(touchDownEvent),
                 .hostSleep(holdDelay),

--- a/Sources/AXe/Utilities/Batch/Command+BatchConvertible.swift
+++ b/Sources/AXe/Utilities/Batch/Command+BatchConvertible.swift
@@ -29,31 +29,22 @@ private func resolveBatchTapPoint(
     elementType: String?,
     logger: AxeLogger
 ) async throws -> (resolution: TapResolution, roots: [AccessibilityElement]) {
-    let roots = try await context.accessibilityRoots(logger: logger)
-    do {
-        let resolution = try AccessibilityTargetResolver.resolveTap(roots: roots, query: query, elementType: elementType)
-        return (resolution, roots)
-    } catch let error as ElementResolutionError where error.isNotFound && context.waitTimeout > 0 {
-        let clock = ContinuousClock()
-        let deadline = clock.now + .seconds(context.waitTimeout)
-        var lastError = error
-
-        while clock.now < deadline {
-            logger.info().log("Element not found, retrying in \(context.pollInterval)s…")
-            try await Task.sleep(for: .seconds(context.pollInterval))
-
-            let freshRoots = try await context.accessibilityRoots(logger: logger, forceRefresh: true)
-            do {
-                let resolution = try AccessibilityTargetResolver.resolveTap(roots: freshRoots, query: query, elementType: elementType)
-                return (resolution, freshRoots)
-            } catch let retryError as ElementResolutionError where retryError.isNotFound {
-                lastError = retryError
-                continue
-            }
-        }
-
-        throw lastError
+    var isFirstFetch = true
+    var latestRoots: [AccessibilityElement] = []
+    let resolution = try await AccessibilityPoller.pollForResolution(
+        query: query,
+        waitTimeout: context.waitTimeout,
+        pollInterval: context.pollInterval,
+        elementType: elementType,
+        logger: logger
+    ) {
+        let forceRefresh = !isFirstFetch
+        isFirstFetch = false
+        let roots = try await context.accessibilityRoots(logger: logger, forceRefresh: forceRefresh)
+        latestRoots = roots
+        return roots
     }
+    return (resolution, latestRoots)
 }
 
 func parseCommaSeparatedIntsStrict(_ rawValue: String, fieldName: String) throws -> [Int] {

--- a/Sources/AXe/Utilities/HIDInteractor.swift
+++ b/Sources/AXe/Utilities/HIDInteractor.swift
@@ -12,6 +12,8 @@ struct HIDInteractor {
         let hid: FBSimulatorHID
     }
 
+
+
     // Cache for HID connections per simulator
     private static var hidConnections: [String: FBSimulatorHID] = [:]
 
@@ -71,6 +73,53 @@ struct HIDInteractor {
         let session = try await makeSession(for: simulatorUDID, logger: logger)
         try await performHIDEvent(event, in: session, logger: logger)
     }
+
+    static func performPhysicalTap(
+        at point: (x: Double, y: Double),
+        preDelay: Double?,
+        postDelay: Double?,
+        for simulatorUDID: String,
+        logger: AxeLogger
+    ) async throws {
+        let session = try await makeSession(for: simulatorUDID, logger: logger)
+        try await performPhysicalTap(at: point, preDelay: preDelay, postDelay: postDelay, in: session, logger: logger)
+    }
+
+    static func performPhysicalTap(
+        at point: (x: Double, y: Double),
+        preDelay: Double?,
+        postDelay: Double?,
+        in session: Session,
+        logger: AxeLogger
+    ) async throws {
+        if let preDelay, preDelay > 0 {
+            logger.info().log("Pre-delay: \(preDelay)s")
+            try await Task.sleep(for: .seconds(preDelay))
+        }
+
+        let touchDownEvent = FBSimulatorHIDEvent.touchDownAt(x: point.x, y: point.y)
+        let touchUpEvent = FBSimulatorHIDEvent.touchUpAt(x: point.x, y: point.y)
+        var didTouchDown = false
+
+        do {
+            try await performHIDEvent(touchDownEvent, in: session, logger: logger)
+            didTouchDown = true
+            try await Task.sleep(for: .seconds(TapTiming.defaultHoldDuration))
+            try await performHIDEvent(touchUpEvent, in: session, logger: logger)
+            didTouchDown = false
+        } catch {
+            if didTouchDown {
+                try? await performHIDEvent(touchUpEvent, in: session, logger: logger)
+            }
+            throw error
+        }
+
+        if let postDelay, postDelay > 0 {
+            logger.info().log("Post-delay: \(postDelay)s")
+            try await Task.sleep(for: .seconds(postDelay))
+        }
+    }
+
 
     // Get or create a cached HID connection (matching CompanionLib's connectToHID behavior)
     private static func getOrCreateHIDConnection(for simulator: FBSimulator, logger: AxeLogger) async throws -> FBSimulatorHID {

--- a/Tests/AccessibilityTargetResolverTests.swift
+++ b/Tests/AccessibilityTargetResolverTests.swift
@@ -93,6 +93,44 @@ struct AccessibilityTargetResolverTests {
         #expect(resolution.isSwitchLikeControl)
     }
 
+    @Test("Matched label ignores nested sibling switch descendants")
+    func matchedLabelIgnoresNestedSiblingSwitchDescendants() throws {
+        let roots = try decodeElements(
+            """
+            [
+              {
+                "type": "Cell",
+                "frame": { "x": 0, "y": 100, "width": 390, "height": 100 },
+                "children": [
+                  {
+                    "type": "StaticText",
+                    "frame": { "x": 16, "y": 120, "width": 140, "height": 20 },
+                    "AXLabel": "Weather Alerts"
+                  },
+                  {
+                    "type": "Cell",
+                    "frame": { "x": 220, "y": 110, "width": 150, "height": 60 },
+                    "children": [
+                      {
+                        "type": "Switch",
+                        "frame": { "x": 300, "y": 125, "width": 50, "height": 30 },
+                        "AXLabel": "Unrelated Nested Switch"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+            """
+        )
+
+        let resolution = try AccessibilityTargetResolver.resolveTap(roots: roots, query: .label("Weather Alerts"))
+
+        #expect(resolution.point.x == 86)
+        #expect(resolution.point.y == 130)
+        #expect(!resolution.isSwitchLikeControl)
+    }
+
     @Test("Wide switch-like rows use trailing activation point")
     func wideSwitchLikeRowsUseTrailingActivationPoint() throws {
         let roots = try decodeElements(
@@ -135,6 +173,56 @@ struct AccessibilityTargetResolverTests {
 
         #expect(point.x == 30)
         #expect(point.y == 30)
+    }
+
+    @Test("Duplicate AXIdentifier does not identify a different ancestor")
+    func duplicateAXIdentifierDoesNotIdentifyDifferentAncestor() throws {
+        let roots = try decodeElements(
+            """
+            [
+              {
+                "type": "Cell",
+                "frame": { "x": 0, "y": 100, "width": 390, "height": 60 },
+                "children": [
+                  {
+                    "type": "StaticText",
+                    "frame": { "x": 16, "y": 120, "width": 140, "height": 20 },
+                    "AXLabel": "Unrelated Label",
+                    "AXIdentifier": "shared-label-id"
+                  },
+                  {
+                    "type": "Switch",
+                    "frame": { "x": 300, "y": 110, "width": 50, "height": 30 },
+                    "AXLabel": "Unrelated Switch"
+                  }
+                ]
+              },
+              {
+                "type": "Cell",
+                "frame": { "x": 0, "y": 200, "width": 390, "height": 60 },
+                "children": [
+                  {
+                    "type": "StaticText",
+                    "frame": { "x": 16, "y": 220, "width": 140, "height": 20 },
+                    "AXLabel": "Weather Alerts",
+                    "AXIdentifier": "shared-label-id"
+                  },
+                  {
+                    "type": "Switch",
+                    "frame": { "x": 100, "y": 210, "width": 50, "height": 30 },
+                    "AXLabel": "Weather Alerts Switch"
+                  }
+                ]
+              }
+            ]
+            """
+        )
+
+        let resolution = try AccessibilityTargetResolver.resolveTap(roots: roots, query: .label("Weather Alerts"))
+
+        #expect(resolution.point.x == 125)
+        #expect(resolution.point.y == 225)
+        #expect(resolution.isSwitchLikeControl)
     }
 
     @Test("Elements with same type and frame but different roles are distinct")

--- a/Tests/AccessibilityTargetResolverTests.swift
+++ b/Tests/AccessibilityTargetResolverTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+@testable import AXe
+
+@Suite("Accessibility Target Resolver Tests")
+struct AccessibilityTargetResolverTests {
+    @Test("Selector tap point uses contained switch activation frame")
+    func selectorTapPointUsesContainedSwitchActivationFrame() throws {
+        let roots = try decodeElements(
+            """
+            [
+              {
+                "type": "Cell",
+                "frame": { "x": 0, "y": 100, "width": 390, "height": 60 },
+                "AXLabel": "Weather Alerts",
+                "children": [
+                  {
+                    "type": "Switch",
+                    "frame": { "x": 300, "y": 110, "width": 50, "height": 30 },
+                    "AXLabel": "Weather Alerts",
+                    "AXUniqueId": "weather-alerts-switch"
+                  }
+                ]
+              }
+            ]
+            """
+        )
+
+        let point = try AccessibilityTargetResolver.resolveTapPoint(roots: roots, query: .label("Weather Alerts"))
+
+        #expect(point.x == 325)
+        #expect(point.y == 125)
+    }
+
+    @Test("Matched row uses contained switch with different label")
+    func matchedRowUsesContainedSwitchWithDifferentLabel() throws {
+        let roots = try decodeElements(
+            """
+            [
+              {
+                "type": "Cell",
+                "frame": { "x": 0, "y": 100, "width": 390, "height": 60 },
+                "AXLabel": "Weather Alerts",
+                "children": [
+                  {
+                    "type": "Switch",
+                    "frame": { "x": 300, "y": 110, "width": 50, "height": 30 },
+                    "AXLabel": "Off"
+                  }
+                ]
+              }
+            ]
+            """
+        )
+
+        let point = try AccessibilityTargetResolver.resolveTapPoint(roots: roots, query: .label("Weather Alerts"))
+
+        #expect(point.x == 325)
+        #expect(point.y == 125)
+    }
+
+    @Test("Matched label uses sibling switch in nearest container")
+    func matchedLabelUsesSiblingSwitchInNearestContainer() throws {
+        let roots = try decodeElements(
+            """
+            [
+              {
+                "type": "Cell",
+                "frame": { "x": 0, "y": 100, "width": 390, "height": 60 },
+                "children": [
+                  {
+                    "type": "StaticText",
+                    "frame": { "x": 16, "y": 120, "width": 140, "height": 20 },
+                    "AXLabel": "Weather Alerts"
+                  },
+                  {
+                    "type": "CheckBox",
+                    "role_description": "switch",
+                    "subrole": "AXSwitch",
+                    "frame": { "x": 300, "y": 110, "width": 50, "height": 30 },
+                    "AXValue": "0"
+                  }
+                ]
+              }
+            ]
+            """
+        )
+
+        let resolution = try AccessibilityTargetResolver.resolveTap(roots: roots, query: .label("Weather Alerts"))
+
+        #expect(resolution.point.x == 325)
+        #expect(resolution.point.y == 125)
+        #expect(resolution.isSwitchLikeControl)
+    }
+
+    @Test("Wide switch-like rows use trailing activation point")
+    func wideSwitchLikeRowsUseTrailingActivationPoint() throws {
+        let roots = try decodeElements(
+            """
+            [
+              {
+                "type": "CheckBox",
+                "role_description": "switch",
+                "subrole": "AXSwitch",
+                "frame": { "x": 16, "y": 180, "width": 370, "height": 28 },
+                "AXLabel": "SwiftUI Weather Alerts",
+                "AXValue": "0"
+              }
+            ]
+            """
+        )
+
+        let point = try AccessibilityTargetResolver.resolveTapPoint(roots: roots, query: .label("SwiftUI Weather Alerts"))
+
+        #expect(point.x == 355)
+        #expect(point.y == 194)
+    }
+
+    @Test("Identifier matching accepts AXIdentifier when AXUniqueId is missing")
+    func identifierMatchingAcceptsAXIdentifier() throws {
+        let roots = try decodeElements(
+            """
+            [
+              {
+                "type": "Switch",
+                "frame": { "x": 10, "y": 20, "width": 40, "height": 20 },
+                "AXLabel": "Weather Alerts",
+                "AXIdentifier": "weather-alerts-switch"
+              }
+            ]
+            """
+        )
+
+        let point = try AccessibilityTargetResolver.resolveTapPoint(roots: roots, query: .id("weather-alerts-switch"))
+
+        #expect(point.x == 30)
+        #expect(point.y == 30)
+    }
+
+    private func decodeElements(_ json: String) throws -> [AccessibilityElement] {
+        let data = try #require(json.data(using: .utf8))
+        return try JSONDecoder().decode([AccessibilityElement].self, from: data)
+    }
+}

--- a/Tests/AccessibilityTargetResolverTests.swift
+++ b/Tests/AccessibilityTargetResolverTests.swift
@@ -137,6 +137,40 @@ struct AccessibilityTargetResolverTests {
         #expect(point.y == 30)
     }
 
+    @Test("Elements with same type and frame but different roles are distinct")
+    func elementsWithSameTypeAndFrameButDifferentRolesAreDistinct() throws {
+        let roots = try decodeElements(
+            """
+            [
+              {
+                "type": "Cell",
+                "frame": { "x": 0, "y": 100, "width": 390, "height": 60 },
+                "children": [
+                  {
+                    "type": "StaticText",
+                    "frame": { "x": 16, "y": 120, "width": 140, "height": 20 },
+                    "AXValue": "1"
+                  },
+                  {
+                    "type": "CheckBox",
+                    "role_description": "switch",
+                    "subrole": "AXSwitch",
+                    "frame": { "x": 300, "y": 110, "width": 50, "height": 30 },
+                    "AXValue": "0"
+                  }
+                ]
+              }
+            ]
+            """
+        )
+
+        let resolution = try AccessibilityTargetResolver.resolveTap(roots: roots, query: .value("1"))
+
+        #expect(resolution.point.x == 86)
+        #expect(resolution.point.y == 130)
+        #expect(!resolution.isSwitchLikeControl)
+    }
+
     private func decodeElements(_ json: String) throws -> [AccessibilityElement] {
         let data = try #require(json.data(using: .utf8))
         return try JSONDecoder().decode([AccessibilityElement].self, from: data)

--- a/Tests/BatchTests.swift
+++ b/Tests/BatchTests.swift
@@ -189,6 +189,40 @@ struct BatchTests {
         #expect(settingsOpened != nil)
     }
 
+    @Test("Batch selector taps toggle SwiftUI and UIKit switches")
+    func selectorTapsToggleSwitches() async throws {
+        try await TestHelpers.launchPlaygroundApp(to: "switch-test")
+
+        try await TestHelpers.runAxeCommand(
+            "batch --ax-cache perStep --step \"tap --label 'SwiftUI Weather Alerts'\" --step \"tap --label 'UIKit Weather Alerts'\"",
+            simulatorUDID: defaultSimulatorUDID
+        )
+
+        let swiftUIState = try await TestHelpers.waitForLabel(containing: "SwiftUI Weather Alerts:", timeout: 3) {
+            $0 == "SwiftUI Weather Alerts: On"
+        }
+        let uiKitState = try await TestHelpers.waitForLabel(containing: "UIKit Weather Alerts:", timeout: 3) {
+            $0 == "UIKit Weather Alerts: On"
+        }
+        #expect(swiftUIState == "SwiftUI Weather Alerts: On")
+        #expect(uiKitState == "UIKit Weather Alerts: On")
+    }
+
+    @Test("Batch tap step automatic overrides simulator batch tap style for switches")
+    func tapStepAutomaticOverridesSimulatorBatchStyleForSwitches() async throws {
+        try await TestHelpers.launchPlaygroundApp(to: "switch-test")
+
+        try await TestHelpers.runAxeCommand(
+            "batch --tap-style simulator --step \"tap --label 'SwiftUI Weather Alerts' --tap-style automatic\"",
+            simulatorUDID: defaultSimulatorUDID
+        )
+
+        let swiftUIState = try await TestHelpers.waitForLabel(containing: "SwiftUI Weather Alerts:", timeout: 3) {
+            $0 == "SwiftUI Weather Alerts: On"
+        }
+        #expect(swiftUIState == "SwiftUI Weather Alerts: On")
+    }
+
     @Test("Batch login flow fails without waiting for post-sign-in screen")
     func loginFlowFailsWithoutWait() async throws {
         try await TestHelpers.launchPlaygroundApp(to: "batch-login-flow")

--- a/Tests/BatchTests.swift
+++ b/Tests/BatchTests.swift
@@ -198,10 +198,10 @@ struct BatchTests {
             simulatorUDID: defaultSimulatorUDID
         )
 
-        let swiftUIState = try await TestHelpers.waitForLabel(containing: "SwiftUI Weather Alerts:", timeout: 3) {
+        let swiftUIState = try await waitForLabel(containing: "SwiftUI Weather Alerts:", timeout: 3) {
             $0 == "SwiftUI Weather Alerts: On"
         }
-        let uiKitState = try await TestHelpers.waitForLabel(containing: "UIKit Weather Alerts:", timeout: 3) {
+        let uiKitState = try await waitForLabel(containing: "UIKit Weather Alerts:", timeout: 3) {
             $0 == "UIKit Weather Alerts: On"
         }
         #expect(swiftUIState == "SwiftUI Weather Alerts: On")
@@ -217,7 +217,7 @@ struct BatchTests {
             simulatorUDID: defaultSimulatorUDID
         )
 
-        let swiftUIState = try await TestHelpers.waitForLabel(containing: "SwiftUI Weather Alerts:", timeout: 3) {
+        let swiftUIState = try await waitForLabel(containing: "SwiftUI Weather Alerts:", timeout: 3) {
             $0 == "SwiftUI Weather Alerts: On"
         }
         #expect(swiftUIState == "SwiftUI Weather Alerts: On")

--- a/Tests/TapTests.swift
+++ b/Tests/TapTests.swift
@@ -197,6 +197,54 @@ struct TapTests {
         )
     }
 
+    @Test("Selector tap toggles SwiftUI Toggle")
+    func selectorTapTogglesSwiftUIToggle() async throws {
+        try await TestHelpers.launchPlaygroundApp(to: "switch-test")
+
+        try await TestHelpers.runAxeCommand("tap --label 'SwiftUI Weather Alerts'", simulatorUDID: defaultSimulatorUDID)
+
+        let state = try await TestHelpers.waitForLabel(containing: "SwiftUI Weather Alerts:", timeout: 3) {
+            $0 == "SwiftUI Weather Alerts: On"
+        }
+        #expect(state == "SwiftUI Weather Alerts: On")
+    }
+
+    @Test("Selector tap toggles UIKit UISwitch")
+    func selectorTapTogglesUIKitSwitch() async throws {
+        try await TestHelpers.launchPlaygroundApp(to: "switch-test")
+
+        try await TestHelpers.runAxeCommand("tap --label 'UIKit Weather Alerts'", simulatorUDID: defaultSimulatorUDID)
+
+        let state = try await TestHelpers.waitForLabel(containing: "UIKit Weather Alerts:", timeout: 3) {
+            $0 == "UIKit Weather Alerts: On"
+        }
+        #expect(state == "UIKit Weather Alerts: On")
+    }
+
+    @Test("Coordinate tap toggles switch center")
+    func coordinateTapTogglesSwitchCenter() async throws {
+        try await TestHelpers.launchPlaygroundApp(to: "switch-test")
+
+        let uiState = try await TestHelpers.getUIState()
+        guard let switchElement = UIStateParser.findElement(in: uiState, matching: {
+            $0.label == "UIKit Weather Alerts" && $0.roleDescription == "switch"
+        }) else {
+            throw TestError.elementNotFound("UIKit switch not found")
+        }
+        guard let frame = switchElement.frame else {
+            throw TestError.unexpectedState("UIKit switch has no frame")
+        }
+
+        let centerX = frame.x + (frame.width / 2.0)
+        let centerY = frame.y + (frame.height / 2.0)
+        try await TestHelpers.runAxeCommand("tap -x \(centerX) -y \(centerY) --tap-style physical", simulatorUDID: defaultSimulatorUDID)
+
+        let state = try await TestHelpers.waitForLabel(containing: "UIKit Weather Alerts:", timeout: 3) {
+            $0 == "UIKit Weather Alerts: On"
+        }
+        #expect(state == "UIKit Weather Alerts: On")
+    }
+
     @Test("At least one tap registers at screen edges")
     func tapAtEdgesRegistersAtLeastOne() async throws {
         // Arrange

--- a/Tests/TestUtilities.swift
+++ b/Tests/TestUtilities.swift
@@ -417,6 +417,30 @@ struct TestHelpers {
 
         throw TestError.unexpectedState("Unable to reset simulator to portrait fixture layout")
     }
+
+    static func waitForLabel(
+        containing text: String,
+        timeout: TimeInterval,
+        simulatorUDID: String? = nil,
+        satisfies predicate: (String) -> Bool
+    ) async throws -> String {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastValue: String?
+
+        while Date() < deadline {
+            let uiState = try await getUIState(simulatorUDID: simulatorUDID)
+            if let element = UIStateParser.findElementContainingLabel(in: uiState, containing: text),
+               let label = element.label {
+                lastValue = label
+                if predicate(label) {
+                    return label
+                }
+            }
+            try await Task.sleep(nanoseconds: 200_000_000)
+        }
+
+        throw TestError.unexpectedState("Timed out waiting for label containing '\(text)'. Last value: \(lastValue ?? "none")")
+    }
     
     @discardableResult
     static func runAxeCommand(

--- a/USAGE_EXAMPLES.md
+++ b/USAGE_EXAMPLES.md
@@ -63,6 +63,9 @@ axe tap -x 100 -y 200 --udid SIMULATOR_UDID
 # Tap by accessibility element (uses describe-ui accessibility tree)
 axe tap --id "Safari" --udid SIMULATOR_UDID
 axe tap --label "Safari" --udid SIMULATOR_UDID
+axe tap --label "Weather Alerts" --udid SIMULATOR_UDID  # Auto-uses physical touch for matched switches/toggles
+axe tap --label "Submit" --tap-style simulator --udid SIMULATOR_UDID  # Force FBSimulator tapAt
+axe tap -x 320 -y 780 --tap-style physical --udid SIMULATOR_UDID  # Force touch down/up for coordinates
 
 # Tap with timing controls
 axe tap -x 100 -y 200 --pre-delay 1.0 --post-delay 0.5 --udid SIMULATOR_UDID
@@ -173,7 +176,19 @@ axe batch --udid SIMULATOR_UDID --file steps.txt
 # For large type steps, chunked mode is default; optional composite mode:
 axe batch --udid SIMULATOR_UDID --type-submission composite \
   --step "type 'some long string here'"
+
+# Toggle a setting switch by label. Automatic tap style uses physical touch for matched switches/toggles.
+axe batch --udid SIMULATOR_UDID \
+  --step "tap --label 'Weather Alerts'"
+
+# Override tap style for all tap steps in a batch, or for one tap step.
+axe batch --udid SIMULATOR_UDID --tap-style physical \
+  --step "tap -x 320 -y 780"
+axe batch --udid SIMULATOR_UDID \
+  --step "tap --label 'Submit' --tap-style simulator"
 ```
+
+Selector taps activate switch/toggle controls at the control's activation point when the matched row or label contains one switch/toggle. The default `--tap-style automatic` uses physical touch down/up for those switch/toggle activations and FBSimulator `tapAt` for normal taps.
 
 Simple behavior rules:
 - One-step source only: `--step`, `--file`, or `--stdin`.


### PR DESCRIPTION
Fix selector-based switch and toggle activation in AXe.

Weather-style switch controls can appear as wide accessibility rows or as `CheckBox` elements with switch role metadata, so resolving to the geometric center can miss the actual activation target. This updates tap resolution to recognize richer switch metadata, choose the switch activation point, and handle both descendant and sibling switch layouts.

Normal taps keep the existing simulator `tapAt` path by default. The new `--tap-style automatic` behavior only switches to physical touch down/up for matched switch/toggle activations, with `--tap-style simulator` and `--tap-style physical` available for explicit control. Batch tap steps mirror direct tap semantics and can be configured at either the batch or step level.

Adds AxePlayground coverage for SwiftUI `Toggle` and UIKit `UISwitch`, plus resolver and E2E regression tests. The docs, changelog, and bundled AXe skill references are updated for the new behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tap dispatch and accessibility resolution logic (including new physical touch path and new resolution heuristics), which can affect interaction correctness across many UI elements and batch flows.
> 
> **Overview**
> **Selector-based `tap` now resolves an *activation point* (not just element center) and reliably redirects row/label matches to a single contained or sibling switch/toggle when present.** Accessibility decoding/normalization is expanded (e.g., `Toggle`, switch role metadata, `AXIdentifier` fallback) and element comparison is tightened to avoid misidentifying distinct ancestors.
> 
> **Adds `--tap-style` (`automatic|simulator|physical`) to `tap` and `batch`** so switch/toggle activations default to physical touch down/up while normal taps continue using simulator `tapAt`; batch plans gain a `physicalTap` primitive and runner support.
> 
> Adds a new Playground `SwitchTestView` plus unit + E2E tests covering switch/toggle activation and tap-style overrides, and updates docs/skill references/README/changelog to reflect the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3739739c6a20a10419d65af98983f80671ece10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->