### PR TITLE
Add .claude folder to .gitignore

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "additionalDirectories": [
-      "/Volumes/Developer/idb"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ Temporary Items
 .vscode
 /.cursorrules
 
+# Claude AI
+.claude
+
 # Other
 /keys
 /buildServer.json


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the `.claude` folder from git tracking and adds it to `.gitignore`.

The `.claude` folder contains local Claude AI settings that should not be tracked in version control, similar to other IDE-specific configuration folders like `.vscode`.

**Changes:**
- Added `.claude` to `.gitignore`
- Removed `.claude/settings.local.json` from git tracking

Resolves the issue raised in the original PR discussion.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a517fabd-6957-4cd0-beae-be439e3c0615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a517fabd-6957-4cd0-beae-be439e3c0615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

