### PR TITLE
ci: Include IDB patch hash in release caches

### DIFF
--- a/.github/workflows/release-shared.yml
+++ b/.github/workflows/release-shared.yml
@@ -52,19 +52,26 @@ jobs:
             --run-number "${{ github.run_number }}" \
             >> "$GITHUB_OUTPUT"
 
+      - name: Resolve IDB cache inputs
+        id: idb_inputs
+        run: |
+          set -euo pipefail
+          PINNED_IDB_COMMIT=$(grep '^IDB_GIT_REF=' scripts/build.sh | sed -E 's/^IDB_GIT_REF="\$\{IDB_GIT_REF:-([^}]*)\}"$/\1/')
+          PATCH_HASH=$(find patches/idb -name '*.patch' -type f | sort | xargs shasum -a 256 | shasum -a 256 | awk '{print $1}')
+          echo "idb_commit=$PINNED_IDB_COMMIT" >> "$GITHUB_OUTPUT"
+          echo "patch_hash=$PATCH_HASH" >> "$GITHUB_OUTPUT"
+
       - name: Restore IDB repository cache
         uses: actions/cache/restore@v4
         with:
           path: idb_checkout
-          key: idb-repo-${{ runner.os }}-dummy
-          restore-keys: |
-            idb-repo-${{ runner.os }}-
+          key: idb-repo-${{ runner.os }}-${{ steps.idb_inputs.outputs.idb_commit }}-${{ steps.idb_inputs.outputs.patch_hash }}
 
       - name: Check IDB repository freshness
         id: idb_check
         run: |
           set -euo pipefail
-          PINNED_IDB_COMMIT=$(grep '^IDB_GIT_REF=' scripts/build.sh | sed -E 's/^IDB_GIT_REF="\$\{IDB_GIT_REF:-([^}]*)\}"$/\1/')
+          PINNED_IDB_COMMIT="${{ steps.idb_inputs.outputs.idb_commit }}"
           echo "idb_commit=$PINNED_IDB_COMMIT" >> "$GITHUB_OUTPUT"
 
           if [ -d "idb_checkout/.git" ]; then
@@ -81,13 +88,13 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: build_products/Frameworks
-          key: frameworks-${{ runner.os }}-${{ steps.idb_check.outputs.idb_commit }}
+          key: frameworks-${{ runner.os }}-${{ steps.idb_check.outputs.idb_commit }}-${{ steps.idb_inputs.outputs.patch_hash }}
 
       - name: Restore XCFramework cache
         uses: actions/cache/restore@v4
         with:
           path: build_products/XCFrameworks
-          key: xcframeworks-${{ runner.os }}-${{ steps.idb_check.outputs.idb_commit }}
+          key: xcframeworks-${{ runner.os }}-${{ steps.idb_check.outputs.idb_commit }}-${{ steps.idb_inputs.outputs.patch_hash }}
 
       - name: Check XCFramework outputs
         id: xcframework_check
@@ -195,21 +202,21 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: idb_checkout
-          key: idb-repo-${{ runner.os }}-${{ steps.idb_check.outputs.idb_commit }}
+          key: idb-repo-${{ runner.os }}-${{ steps.idb_check.outputs.idb_commit }}-${{ steps.idb_inputs.outputs.patch_hash }}
 
       - name: Save runtime Frameworks cache
         if: steps.idb_check.outputs.needs_setup == 'true' || steps.xcframework_check.outputs.needs_build == 'true'
         uses: actions/cache/save@v4
         with:
           path: build_products/Frameworks
-          key: frameworks-${{ runner.os }}-${{ steps.idb_check.outputs.idb_commit }}
+          key: frameworks-${{ runner.os }}-${{ steps.idb_check.outputs.idb_commit }}-${{ steps.idb_inputs.outputs.patch_hash }}
 
       - name: Save XCFramework cache
         if: steps.idb_check.outputs.needs_setup == 'true' || steps.xcframework_check.outputs.needs_build == 'true'
         uses: actions/cache/save@v4
         with:
           path: build_products/XCFrameworks
-          key: xcframeworks-${{ runner.os }}-${{ steps.idb_check.outputs.idb_commit }}
+          key: xcframeworks-${{ runner.os }}-${{ steps.idb_check.outputs.idb_commit }}-${{ steps.idb_inputs.outputs.patch_hash }}
 
       - name: Prepare - Clean Swift build environment
         run: |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -111,6 +111,24 @@ function verify_macho_has_arch() {
   fi
 }
 
+function verify_fbsimulatorcontrol_has_xctest_client_type_patch() {
+  local binary_path="$1"
+
+  if [[ ! -f "$binary_path" ]]; then
+    echo "❌ Error: FBSimulatorControl binary not found for accessibility patch verification: $binary_path"
+    exit 1
+  fi
+
+  local client_type_references
+  client_type_references=$(strings -a "$binary_path" | grep -F "setClientType:" || true)
+  if [[ -z "$client_type_references" ]]; then
+    echo "❌ Error: FBSimulatorControl is missing the XCTest accessibility client type patch"
+    echo "   Expected to find selector reference 'setClientType:' in: $binary_path"
+    echo "   Rebuild IDB frameworks after applying patches/idb/accessibility-client-type-for-xctest.patch."
+    exit 1
+  fi
+}
+
 # Function to invoke xcodebuild, optionally with xcpretty
 function invoke_xcodebuild() {
   local arguments=("$@")
@@ -575,6 +593,9 @@ function verify_xcframework_inputs() {
     fi
     verify_macho_has_arch "${framework_binary}" "arm64"
     verify_macho_has_arch "${framework_binary}" "x86_64"
+    if [[ "${framework_name}" == "FBSimulatorControl" ]]; then
+      verify_fbsimulatorcontrol_has_xctest_client_type_patch "${framework_binary}"
+    fi
   done
 
   print_success "XCFramework inputs include arm64 and x86_64 slices"
@@ -609,6 +630,9 @@ function verify_release_architectures() {
     fi
     verify_macho_has_arch "${framework_binary}" "arm64"
     verify_macho_has_arch "${framework_binary}" "x86_64"
+    if [[ "${framework_name}" == "FBSimulatorControl" ]]; then
+      verify_fbsimulatorcontrol_has_xctest_client_type_patch "${framework_binary}"
+    fi
   done
 
   print_success "Release artifacts include arm64 and x86_64 slices"


### PR DESCRIPTION
Ensure AXe release builds invalidate cached IDB and framework artifacts when local IDB patches change.

The release workflow previously keyed IDB/framework caches mostly by the pinned upstream IDB commit. That meant adding or changing a patch under `patches/idb/` could still reuse artifacts built from the same upstream commit before the patch existed, allowing stale frameworks into a release.

This keys the IDB checkout, runtime Frameworks, and XCFramework caches by both the pinned IDB commit and a hash of `patches/idb/*.patch`. It also adds release artifact verification that fails when `FBSimulatorControl` does not contain evidence of the XCTest accessibility client type patch.

Validated locally with YAML parsing, shell syntax checking, and `scripts/build.sh verify-xcframeworks`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI cache keying and build-time binary string checks only; no runtime product logic or auth/data paths change.
> 
> **Overview**
> Release CI now **invalidates IDB-related caches when local patches change**, not only when the pinned upstream IDB commit changes. A new workflow step derives the pinned commit from `scripts/build.sh` and a **combined SHA-256 of all `patches/idb/*.patch` files**; that `patch_hash` is appended to restore/save keys for the IDB checkout, runtime Frameworks, and XCFramework caches (replacing the prior dummy/partial keys).
> 
> `scripts/build.sh` adds a **release verification guard** on `FBSimulatorControl`: `verify-xcframeworks` and `verify-arches` fail if the framework binary does not contain a `setClientType:` string, catching releases built without the XCTest accessibility client-type patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31bbb59700393caa048b1455b4c41064b08fbd04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->