### PR TITLE
Fix SimulatorKit lookup for Xcode 27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the AXe iOS testing framework will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed SimulatorKit loading with Xcode 27 beta by checking Xcode's `Contents/SharedFrameworks` layout before falling back to the legacy private-framework path.
+
 ## [v1.7.1] - 2026-06-02
 
 ### Added

--- a/patches/idb/xcode27-macos-deployment-target.patch
+++ b/patches/idb/xcode27-macos-deployment-target.patch
@@ -1,0 +1,36 @@
+diff --git a/Configuration/Shared.xcconfig b/Configuration/Shared.xcconfig
+index d0746b8e..f4dfe6ce 100644
+--- a/Configuration/Shared.xcconfig
++++ b/Configuration/Shared.xcconfig
+@@ -51,6 +51,6 @@ GCC_WARN_UNUSED_VARIABLE = YES
+ 
+ // SDK & OS Versions
+-MACOSX_DEPLOYMENT_TARGET = 10.14
++MACOSX_DEPLOYMENT_TARGET = 12.0
+ SDKROOT = macosx
+ 
+ // Compile-Time Settings
+diff --git a/Shims/Shimulator/Configs/Maculator.xcconfig b/Shims/Shimulator/Configs/Maculator.xcconfig
+index 8cccb535..e4da19b4 100644
+--- a/Shims/Shimulator/Configs/Maculator.xcconfig
++++ b/Shims/Shimulator/Configs/Maculator.xcconfig
+@@ -6,6 +6,6 @@ DYLIB_COMPATIBILITY_VERSION = 1
+ PRODUCT_NAME = Maculator
+ EXECUTABLE_PREFIX = lib
+ SDKROOT = macosx
+-MACOSX_DEPLOYMENT_TARGET = 10.13
++MACOSX_DEPLOYMENT_TARGET = 12.0
+ COPY_PHASE_STRIP = NO
+ CODE_SIGN_IDENTITY = - // Maculator Shims must be CodeSigned, to work for injection.
+diff --git a/Shims/Shimulator/Configs/Shimulator.xcconfig b/Shims/Shimulator/Configs/Shimulator.xcconfig
+index 442e69fe..c3ecee38 100644
+--- a/Shims/Shimulator/Configs/Shimulator.xcconfig
++++ b/Shims/Shimulator/Configs/Shimulator.xcconfig
+@@ -6,6 +6,6 @@ DYLIB_COMPATIBILITY_VERSION = 1
+ PRODUCT_NAME = Shimulator
+ EXECUTABLE_PREFIX = lib
+ SDKROOT = iphonesimulator
+-IPHONEOS_DEPLOYMENT_TARGET = 11.0
++IPHONEOS_DEPLOYMENT_TARGET = 15.0
+ COPY_PHASE_STRIP = NO
+ CODE_SIGN_IDENTITY = -  // Simulator Shims must be CodeSigned, to work for injection.

--- a/patches/idb/xcode27-simulatorkit-sharedframeworks.patch
+++ b/patches/idb/xcode27-simulatorkit-sharedframeworks.patch
@@ -1,0 +1,19 @@
+diff --git a/FBControlCore/Utility/FBWeakFramework+ApplePrivateFrameworks.m b/FBControlCore/Utility/FBWeakFramework+ApplePrivateFrameworks.m
+index 0d09ee653..80db7d89d 100644
+--- a/FBControlCore/Utility/FBWeakFramework+ApplePrivateFrameworks.m
++++ b/FBControlCore/Utility/FBWeakFramework+ApplePrivateFrameworks.m
+@@ -22,7 +22,13 @@ + (instancetype)CoreSimulator
+ 
+ + (instancetype)SimulatorKit
+ {
+-  return [FBWeakFramework xcodeFrameworkWithRelativePath:@"Library/PrivateFrameworks/SimulatorKit.framework" requiredClassNames:@[]];
++  NSString *legacyRelativePath = @"Library/PrivateFrameworks/SimulatorKit.framework";
++  NSString *sharedRelativePath = @"../SharedFrameworks/SimulatorKit.framework";
++  NSString *sharedPath = [FBXcodeConfiguration.developerDirectory stringByAppendingPathComponent:sharedRelativePath];
++  NSString *relativePath = [NSFileManager.defaultManager fileExistsAtPath:sharedPath]
++    ? sharedRelativePath
++    : legacyRelativePath;
++  return [FBWeakFramework xcodeFrameworkWithRelativePath:relativePath requiredClassNames:@[]];
+ }
+ 
+ + (instancetype)DTXConnectionServices


### PR DESCRIPTION
## Summary
- Add an IDB patch so SimulatorKit is loaded from Xcode 27's `Contents/SharedFrameworks` layout when present.
- Preserve the existing `Contents/Developer/Library/PrivateFrameworks` path as the fallback for older Xcode versions.
- Add an Unreleased changelog entry.

## Validation
- Verified all `patches/idb/*.patch` files apply cleanly to AXe's pinned IDB revision `76639e4d0e1741adf391cab36f19fbc59378153e`.
- Built a patched AXe binary from this change in a local spike and verified `axe describe-ui` succeeds under `/Applications/Xcode-27.0.0-Beta.2.app`.
- Verified XcodeBuildMCP `ui-automation snapshot-ui` succeeds with the patched AXe binary, returning a `runtime-snapshot` with 16 elements.

## Notes
This is a compatibility fallback for the Xcode 27 beta framework layout; it does not remove the legacy path used by earlier Xcode releases.