### PR TITLE
Add Claude and Codex skill marketplaces

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "axe",
+  "interface": {
+    "displayName": "AXe"
+  },
+  "plugins": [
+    {
+      "name": "axe",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "axe",
+  "description": "AXe skills for iOS Simulator automation",
+  "owner": {
+    "name": "Cameron Cooke"
+  },
+  "plugins": [
+    {
+      "name": "axe",
+      "source": "./",
+      "description": "Automate iOS Simulators with the AXe CLI",
+      "category": "development"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "axe",
+  "displayName": "AXe",
+  "version": "1.8.0",
+  "description": "Agent-ready AXe CLI guidance for iOS Simulator automation",
+  "author": {
+    "name": "Cameron Cooke"
+  },
+  "homepage": "https://axe-cli.com/docs",
+  "repository": "https://github.com/cameroncooke/AXe",
+  "license": "MIT",
+  "keywords": [
+    "ios",
+    "simulator",
+    "automation",
+    "accessibility"
+  ],
+  "skills": "./Skills/CLI/"
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "axe",
+  "version": "1.8.0",
+  "description": "Agent-ready AXe CLI guidance for iOS Simulator automation.",
+  "author": {
+    "name": "Cameron Cooke",
+    "url": "https://github.com/cameroncooke"
+  },
+  "homepage": "https://axe-cli.com/docs",
+  "repository": "https://github.com/cameroncooke/AXe",
+  "license": "MIT",
+  "keywords": [
+    "ios",
+    "simulator",
+    "automation",
+    "accessibility"
+  ],
+  "skills": "./Skills/CLI/axe",
+  "interface": {
+    "displayName": "AXe",
+    "shortDescription": "Automate iOS Simulators with AXe.",
+    "longDescription": "Provides Codex with AXe CLI guidance for inspecting and automating iOS Simulator interfaces.",
+    "developerName": "Cameron Cooke",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://axe-cli.com/docs",
+    "defaultPrompt": [
+      "Inspect the current iOS Simulator UI with AXe.",
+      "Automate this iOS Simulator flow with AXe.",
+      "Capture and verify the current simulator screen."
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the AXe iOS testing framework will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added Claude Code and Codex plugin marketplaces for installing the bundled AXe skill.
+
 ## [v1.8.0] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@ axe --help
 axe list-simulators
 ```
 
+## Install the AI skill
+
+Install the bundled AXe skill from this repository's marketplace.
+
+Claude Code:
+
+```bash
+claude plugin marketplace add cameroncooke/AXe
+claude plugin install axe@axe
+```
+
+Codex:
+
+```bash
+codex plugin marketplace add cameroncooke/AXe
+codex plugin add axe@axe
+```
+
+> [!NOTE]
+> The marketplace references the existing case-sensitive `Skills/CLI` path directly. It does not include a lowercase `skills/` compatibility symlink, so clients or filesystems that require the conventional lowercase path are unsupported.
+
 ## Xcode compatibility
 
 AXe supports Xcode 26 and Xcode 27. Xcode 27 simulator automation uses Device Hub; Simulator.app is not required.


### PR DESCRIPTION
Adds Claude Code and Codex marketplace manifests for the bundled AXe skill.

Installing through a marketplace keeps the skill in sync as updates ship, so users do not need to update it manually after installation.

The manifests reference the existing case-sensitive `Skills/CLI` path directly without a compatibility symlink; systems requiring a conventional lowercase `skills/` path are unsupported.
