### PR TITLE
feat(describe-ui): Add --include-web-content for WKWebView page content

### DIFF
--- a/AxePlaygroundApp/AxePlayground/ContentView.swift
+++ b/AxePlaygroundApp/AxePlayground/ContentView.swift
@@ -65,6 +65,8 @@ struct ContentView: View {
             SearchableTestView()
         case "toolbar-picker-test":
             ToolbarPickerTestView()
+        case "web-content-test":
+            WebContentTestView()
         case "alert-test":
             AlertTestView()
         case "sheet-test":
@@ -126,7 +128,8 @@ struct MainMenuView: View {
         ("Accessibility", [
             ("slider-value-test", "Slider Value Test", "Numeric AXValue with selector tap"),
             ("searchable-test", "Searchable Test", "Navigation search field targeting"),
-            ("toolbar-picker-test", "Toolbar Picker Test", "Toolbar segmented picker targeting")
+            ("toolbar-picker-test", "Toolbar Picker Test", "Toolbar segmented picker targeting"),
+            ("web-content-test", "Web Content Test", "WKWebView page content in a separate process")
         ]),
         ("Presentation", [
             ("alert-test", "Alert Test", "Alert presentation and button targeting"),

--- a/AxePlaygroundApp/AxePlayground/Views/WebContentTestView.swift
+++ b/AxePlaygroundApp/AxePlayground/Views/WebContentTestView.swift
@@ -1,0 +1,74 @@
+//
+//  WebContentTestView.swift
+//  AxePlayground
+//
+//  Fixture for `describe-ui --include-web-content`: the page content renders in a separate
+//  WebContent process, reachable only by cross-process hit-testing.
+//
+
+import SwiftUI
+import WebKit
+
+struct WebContentTestView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Web Content Playground")
+                .font(.title2)
+                .fontWeight(.bold)
+                .accessibilityIdentifier("web-content-test-title")
+
+            // This label IS in the native tree, so a test can tell "the screen is up" apart from
+            // "the web content was discovered".
+            Text("Native sibling label")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .accessibilityIdentifier("web-content-native-sibling")
+
+            WebContentFixtureView()
+                .accessibilityIdentifier("web-content-test-webview")
+        }
+        .padding()
+        .navigationTitle("Web Content Test")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct WebContentFixtureView: UIViewRepresentable {
+    // Loaded from a string rather than a URL: the fixture must render identically with no network.
+    private static let html = """
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <style>
+              body { font: 17px -apple-system, sans-serif; margin: 12px; }
+              /* Generous vertical spacing so each element sits in its own hit-test grid row. */
+              h1 { font-size: 24px; margin: 0 0 24px; }
+              p, div { margin: 0 0 24px; }
+              button, input { font-size: 17px; padding: 8px; }
+            </style>
+          </head>
+          <body>
+            <h1>AXE_WEB_HEADING</h1>
+            <p>AXE_WEB_PARAGRAPH body text</p>
+            <div><a href="#">AXE_WEB_LINK</a></div>
+            <div><button type="button">AXE_WEB_BUTTON</button></div>
+            <div><input type="text" aria-label="AXE_WEB_FIELD" value="field"></div>
+          </body>
+        </html>
+        """
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView(frame: .zero)
+        webView.isOpaque = false
+        webView.scrollView.isScrollEnabled = false
+        webView.loadHTMLString(Self.html, baseURL: nil)
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {}
+}
+
+#Preview {
+    WebContentTestView()
+}

--- a/Sources/AXe/Commands/DescribeUI.swift
+++ b/Sources/AXe/Commands/DescribeUI.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import FBControlCore
 import Foundation
 
 struct DescribeUI: AsyncParsableCommand {
@@ -18,8 +19,46 @@ struct DescribeUI: AsyncParsableCommand {
     )
     var point: String?
 
+    @Flag(
+        name: .customLong("include-web-content"),
+        help: "Also describe WKWebView and SFSafariViewController page content, which the in-process accessibility walk cannot reach. Discovered elements report \"is_remote\": \"point_grid\"."
+    )
+    var includeWebContent = false
+
+    @Option(
+        name: .customLong("web-content-grid-step"),
+        help: ArgumentHelp(
+            "Spacing in points between web-content hit-test samples; smaller is more thorough but slower. Only applies with --include-web-content.",
+            valueName: "points"
+        )
+    )
+    // 25pt, not the library's 50pt default: at 50pt the gaps between probe rows miss a standard
+    // 20pt-tall link while still returning a complete-looking tree.
+    var webContentGridStep: Double = 25
+
+    @Option(
+        name: .customLong("web-content-max-points"),
+        help: ArgumentHelp(
+            "Cap on hit-tested points when discovering web content (0 = unlimited). Only applies with --include-web-content.",
+            valueName: "count"
+        )
+    )
+    var webContentMaxPoints: UInt = 0
+
     func validate() throws {
         _ = try parsedPoint()
+
+        if includeWebContent {
+            guard webContentGridStep > 0 else {
+                throw ValidationError("--web-content-grid-step must be greater than zero.")
+            }
+            // --point already resolves the element under the cursor across the process boundary.
+            if point != nil {
+                throw ValidationError(
+                    "--include-web-content cannot be combined with --point; a point lookup already resolves web content."
+                )
+            }
+        }
     }
 
     func run() async throws {
@@ -29,12 +68,23 @@ struct DescribeUI: AsyncParsableCommand {
         let jsonData = try await AccessibilityFetcher.fetchAccessibilityInfoJSONData(
             for: simulatorUDID,
             point: try parsedPoint(),
+            remoteContent: remoteContentOptions(),
             logger: logger
         )
         guard let jsonString = String(data: jsonData, encoding: .utf8) else {
             throw CLIError(errorDescription: "Failed to convert accessibility info to JSON string.")
         }
         print(jsonString)
+    }
+
+    private func remoteContentOptions() -> FBAccessibilityRemoteContentOptions? {
+        guard includeWebContent else {
+            return nil
+        }
+        return FBAccessibilityRemoteContentOptions(
+            gridStepSize: CGFloat(webContentGridStep),
+            maxPoints: webContentMaxPoints
+        )
     }
 
     private func parsedPoint() throws -> AccessibilityPoint? {

--- a/Sources/AXe/Commands/DescribeUI.swift
+++ b/Sources/AXe/Commands/DescribeUI.swift
@@ -21,7 +21,7 @@ struct DescribeUI: AsyncParsableCommand {
 
     @Flag(
         name: .customLong("include-web-content"),
-        help: "Also describe WKWebView and SFSafariViewController page content, which the in-process accessibility walk cannot reach. Discovered elements report \"is_remote\": \"point_grid\"."
+        help: "Also describe WKWebView and SFSafariViewController page content, which the in-process accessibility walk cannot reach. Only content currently on screen is found; discovered elements report \"is_remote\": \"point_grid\"."
     )
     var includeWebContent = false
 
@@ -77,6 +77,8 @@ struct DescribeUI: AsyncParsableCommand {
         print(jsonString)
     }
 
+    // The grid covers the whole screen, so points that land outside the web view can return other
+    // out-of-process UI too (the status bar, for example). `region` could bound this if it matters.
     private func remoteContentOptions() -> FBAccessibilityRemoteContentOptions? {
         guard includeWebContent else {
             return nil

--- a/Sources/AXe/Utilities/AccessibilityFetcher.swift
+++ b/Sources/AXe/Utilities/AccessibilityFetcher.swift
@@ -34,6 +34,7 @@ struct AccessibilityFetcher {
     static func fetchAccessibilityInfoJSONData(
         for simulatorUDID: String,
         point: AccessibilityPoint? = nil,
+        remoteContent: FBAccessibilityRemoteContentOptions? = nil,
         logger: AxeLogger,
         recoveryDependencies: AccessibilityRecoveryDependencies = .live
     ) async throws -> Data {
@@ -51,7 +52,7 @@ struct AccessibilityFetcher {
             if let point {
                 return try await fetchAccessibilityInfoJSONData(from: target, at: point)
             }
-            return try await fetchFrontmostAccessibilityInfoJSONData(from: target)
+            return try await fetchFrontmostAccessibilityInfoJSONData(from: target, remoteContent: remoteContent)
         }
     }
 
@@ -92,7 +93,10 @@ struct AccessibilityFetcher {
         return latestData
     }
 
-    private static func fetchFrontmostAccessibilityInfoJSONData(from target: FBSimulator) async throws -> Data {
+    private static func fetchFrontmostAccessibilityInfoJSONData(
+        from target: FBSimulator,
+        remoteContent: FBAccessibilityRemoteContentOptions? = nil
+    ) async throws -> Data {
         var latestData: Data?
         for attempt in 0..<5 {
             // IDB's former `accessibilityElements(withNestedFormat:)` API also serialized the
@@ -100,7 +104,7 @@ struct AccessibilityFetcher {
             let accessibilityElement = try await target.accessibilityElementForFrontmostApplication()
             let data: Data
             do {
-                data = try serializedAccessibilityData(from: accessibilityElement)
+                data = try serializedAccessibilityData(from: accessibilityElement, remoteContent: remoteContent)
                 accessibilityElement.close()
             } catch {
                 accessibilityElement.close()
@@ -251,11 +255,20 @@ struct AccessibilityFetcher {
         process.waitUntilExit()
     }
 
-    private static func serializedAccessibilityData(from accessibilityElement: FBAccessibilityElement) throws -> Data {
+    private static func serializedAccessibilityData(
+        from accessibilityElement: FBAccessibilityElement,
+        remoteContent: FBAccessibilityRemoteContentOptions? = nil
+    ) throws -> Data {
+        // collectFrameCoverage stays off: the serializer fills the coverage grid from every
+        // non-Application frame, and real screens have enough full-screen containers to saturate it
+        // mid-walk, silently skipping every probe. With it off, all grid points are probed;
+        // duplicate hits collapse via PID/frame de-duplication and maxPoints bounds the cost.
+        // `is_remote` is requested only in this mode, so the default JSON schema is unchanged.
         let response = try accessibilityElement.serialize(
             with: FBAccessibilityRequestOptions(
                 nestedFormat: true,
-                keys: accessibilityRequestKeys
+                keys: remoteContent == nil ? accessibilityRequestKeys : accessibilityRequestKeys.union([.isRemote]),
+                remoteContentOptions: remoteContent
             )
         )
         return try serializeAccessibilityInfo(addingCompatibilityDefaults(to: response.elements))

--- a/Sources/AXe/Utilities/AccessibilityFetcher.swift
+++ b/Sources/AXe/Utilities/AccessibilityFetcher.swift
@@ -263,7 +263,8 @@ struct AccessibilityFetcher {
         // non-Application frame, and real screens have enough full-screen containers to saturate it
         // mid-walk, silently skipping every probe. With it off, all grid points are probed;
         // duplicate hits collapse via PID/frame de-duplication and maxPoints bounds the cost.
-        // `is_remote` is requested only in this mode, so the default JSON schema is unchanged.
+        // `is_remote` is requested only in this mode, so the default JSON schema is unchanged. With
+        // it on, grid-discovered elements report "point_grid" and natively walked ones "recursive".
         let response = try accessibilityElement.serialize(
             with: FBAccessibilityRequestOptions(
                 nestedFormat: true,

--- a/Tests/DescribeUITests.swift
+++ b/Tests/DescribeUITests.swift
@@ -21,6 +21,32 @@ struct DescribeUICommandSurfaceTests {
         #expect(result.exitCode != 0)
         #expect(result.output.contains("--point must be in the form x,y using non-negative numbers."))
     }
+
+    @Test("Web content options appear in describe-ui --help")
+    func describeUIHelpIncludesWebContentOptions() async throws {
+        let result = try await TestHelpers.runAxeCommand("describe-ui --help")
+        #expect(result.output.contains("--include-web-content"))
+        #expect(result.output.contains("--web-content-grid-step"))
+        #expect(result.output.contains("--web-content-max-points"))
+    }
+
+    @Test("Non-positive --web-content-grid-step fails with guidance")
+    func nonPositiveGridStepFails() async throws {
+        let result = try await TestHelpers.runAxeCommandAllowFailure(
+            "describe-ui --udid invalid --include-web-content --web-content-grid-step 0"
+        )
+        #expect(result.exitCode != 0)
+        #expect(result.output.contains("--web-content-grid-step must be greater than zero."))
+    }
+
+    @Test("--include-web-content is rejected alongside --point")
+    func webContentWithPointFails() async throws {
+        let result = try await TestHelpers.runAxeCommandAllowFailure(
+            "describe-ui --udid invalid --point 10,10 --include-web-content"
+        )
+        #expect(result.exitCode != 0)
+        #expect(result.output.contains("--include-web-content cannot be combined with --point"))
+    }
 }
 
 @Suite("Describe UI Command Tests", .serialized, .enabled(if: isE2EEnabled))
@@ -138,4 +164,72 @@ struct DescribeUITests {
         #expect(targetedFrame.width == 44)
         #expect(targetedFrame.height == 44)
     }
+
+    @Test("Describe-ui omits WKWebView page content by default")
+    func describeUIOmitsWebContentByDefault() async throws {
+        try await TestHelpers.launchPlaygroundApp(to: "web-content-test")
+        let simulatorUDID = try TestHelpers.requireSimulatorUDID()
+        // Wait until the page is discoverable, so "absent" below means unreachable, not unpainted.
+        _ = try await Self.waitForWebContent(simulatorUDID: simulatorUDID)
+
+        let uiState = try await TestHelpers.getUIState()
+
+        // The screen itself is up...
+        #expect(UIStateParser.findElement(in: uiState, withIdentifier: "web-content-test-webview") != nil)
+        // ...but its page content is rendered by a separate process the in-process walk cannot reach.
+        for label in Self.webFixtureLabels {
+            #expect(
+                UIStateParser.findElementByLabel(in: uiState, label: label) == nil,
+                "\(label) should not appear without --include-web-content"
+            )
+        }
+    }
+
+    @Test("Describe-ui returns WKWebView page content with --include-web-content")
+    func describeUIReturnsWebContentWhenRequested() async throws {
+        try await TestHelpers.launchPlaygroundApp(to: "web-content-test")
+        let simulatorUDID = try TestHelpers.requireSimulatorUDID()
+
+        let roots = try await Self.waitForWebContent(simulatorUDID: simulatorUDID)
+
+        for (label, expectedType) in Self.webFixtureElements {
+            let element = try #require(
+                UIStateParser.findElement(in: roots, matching: { $0.label == label }),
+                "\(label) should be discovered with --include-web-content"
+            )
+            #expect(element.type == expectedType)
+            #expect(element.isRemote == "point_grid")
+            // A hit-tested element carries a real on-screen frame, so it stays tappable by coordinate.
+            let frame = try #require(element.frame)
+            #expect(frame.width > 0)
+            #expect(frame.height > 0)
+        }
+    }
+
+    // WKWebView paints its page asynchronously after the native screen settles; poll until the
+    // fixture heading is discoverable so assertions key on a rendered page.
+    private static func waitForWebContent(simulatorUDID: String) async throws -> [UIElement] {
+        var roots: [UIElement] = []
+        for _ in 0..<20 {
+            let result = try await TestHelpers.runAxeCommand(
+                "describe-ui --include-web-content",
+                simulatorUDID: simulatorUDID
+            )
+            roots = try UIStateParser.parseDescribeUIRoots(result.output)
+            if UIStateParser.findElement(in: roots, matching: { $0.label == "AXE_WEB_HEADING" }) != nil {
+                return roots
+            }
+            try await Task.sleep(nanoseconds: 500_000_000)
+        }
+        return roots
+    }
+
+    private static let webFixtureElements: [(String, String)] = [
+        ("AXE_WEB_HEADING", "Heading"),
+        ("AXE_WEB_LINK", "Link"),
+        ("AXE_WEB_BUTTON", "Button"),
+        ("AXE_WEB_FIELD", "TextField"),
+    ]
+
+    private static let webFixtureLabels: [String] = webFixtureElements.map(\.0)
 }

--- a/Tests/PlaygroundLaunchHelpers.swift
+++ b/Tests/PlaygroundLaunchHelpers.swift
@@ -143,6 +143,8 @@ extension TestHelpers {
                 .label("Unread"),
                 .label("Read"),
             ])
+        // Keyed on a native element: this screen's web content is invisible to a plain describe-ui.
+        case "web-content-test": return .identifier("web-content-test-webview")
         case "alert-test": return .identifier("alert-test-show-alert")
         case "sheet-test": return .identifier("sheet-test-open-sheet")
         case "context-menu-test": return .identifier("context-menu-test-target")

--- a/Tests/TestUIState.swift
+++ b/Tests/TestUIState.swift
@@ -17,6 +17,7 @@ struct UIElement: Decodable {
     let AXValue: String?
     let AXUniqueId: String?
     let AXIdentifier: String?
+    let isRemote: String?
 
     enum CodingKeys: String, CodingKey {
         case type
@@ -35,6 +36,7 @@ struct UIElement: Decodable {
         case AXValue
         case AXUniqueId
         case AXIdentifier
+        case isRemote = "is_remote"
     }
 
     init(from decoder: Decoder) throws {
@@ -56,6 +58,7 @@ struct UIElement: Decodable {
         AXValue = try Self.decodeOptionalScalarString(from: container, forKey: .AXValue)
         AXUniqueId = try Self.decodeOptionalScalarString(from: container, forKey: .AXUniqueId)
         AXIdentifier = try Self.decodeOptionalScalarString(from: container, forKey: .AXIdentifier)
+        isRemote = try Self.decodeOptionalScalarString(from: container, forKey: .isRemote)
     }
 
     private static func decodeOptionalScalarString(


### PR DESCRIPTION
# For Humans

Fixes #65 — opened as a draft to propose the approach.

`describe-ui` can't see inside a WKWebView or SFSafariViewController, because the page renders in a separate WebContent process the in-process accessibility walk never reaches. With the new opt-in `--include-web-content` flag, it hit-tests a grid of screen points across that process boundary and returns the page's headings, links, buttons, and fields as ordinary elements with real tappable frames 🔍. It reuses remote-content options FBControlCore's serializer already supports at the pinned idb rev — no dependency changes, and the default output stays byte-identical when the flag is off.

## Visuals

Before — default walk on the playground's WKWebView fixture screen (page content invisible):

```
$ axe describe-ui --udid <udid> | grep -c AXE_WEB
0
```

After — same screen with the flag; every page element is discovered, typed, framed, and tagged:

```
$ axe describe-ui --include-web-content --udid <udid>
...
{ "AXLabel": "AXE_WEB_HEADING", "type": "Heading",   "frame": {"x": 28, "y": 208, "width": 235, "height": 30}, "is_remote": "point_grid" }
{ "AXLabel": "AXE_WEB_LINK",    "type": "Link",      "frame": {"x": 28, "y": 307, "width": 123, "height": 23}, "is_remote": "point_grid" }
{ "AXLabel": "AXE_WEB_BUTTON",  "type": "Button",    "frame": {"x": 28, "y": 353, "width": 172, "height": 41}, "is_remote": "point_grid" }
{ "AXLabel": "AXE_WEB_FIELD",   "type": "TextField", "frame": {"x": 28, "y": 417, "width": 226, "height": 41}, "is_remote": "point_grid" }
```

(Real output from a booted iPhone 17 Pro simulator, iOS 26.5; trimmed to the discovered elements.)

## Conversation Highlights

| Agent Question | Steven Answer |
|---|---|
| (unprompted direction on the CLI declarations) | "i feel like these options are too verbose" |

That call shaped the final surface: the option help strings are one-liners matching the file's idiom, and the measurement evidence behind the two non-obvious defaults lives in this description instead of inline comments.

## Stack

Not stacked.

**Created with:** claude-fable-5

# For Agents

## Reviewer question

Should `describe-ui` gain an opt-in point-grid discovery path for out-of-process WebKit content, shaped as one enabling flag plus two tuning options (`--web-content-grid-step`, `--web-content-max-points`)?

**Diff size:** 73 changed production lines (`Sources/`); 251 total (+245/−6) including the playground fixture and tests.

## Load-bearing code

1. [`DescribeUI.swift:22-64`](https://github.com/underscoretang/AXe/blob/b0857c2aab711b06aff9698cf0f5e81c96795ab2/Sources/AXe/Commands/DescribeUI.swift#L22-L64) — the three CLI declarations and scoped validation (guards apply only when the flag is on; tuning options document their inertness otherwise).
2. [`AccessibilityFetcher.swift:262-272`](https://github.com/underscoretang/AXe/blob/b0857c2aab711b06aff9698cf0f5e81c96795ab2/Sources/AXe/Utilities/AccessibilityFetcher.swift#L262-L272) — the serializer call: `is_remote` is unioned into the request keys **only** in remote mode, which is what keeps the default JSON schema unchanged; the `collectFrameCoverage` comment marks the decision that looks like a mistake.
3. [`DescribeUITests.swift:167-224`](https://github.com/underscoretang/AXe/blob/b0857c2aab711b06aff9698cf0f5e81c96795ab2/Tests/DescribeUITests.swift#L167-L224) — both E2E legs share a readiness poll (WKWebView paints asynchronously) and assert label, type, `is_remote`, and a positive frame.
4. [`WebContentTestView.swift`](https://github.com/underscoretang/AXe/blob/b0857c2aab711b06aff9698cf0f5e81c96795ab2/AxePlaygroundApp/AxePlayground/Views/WebContentTestView.swift) — deterministic fixture: static HTML, no network, scrolling disabled, native sibling label so tests can tell "screen is up" from "web content discovered".

## Design decisions (the two that look like mistakes until explained)

1. **`collectFrameCoverage` stays off.** Turning it on looks like a free optimization — skip hit-testing points the native walk already covered. In practice the serializer fills the coverage grid from every non-Application frame, and real screens are full of full-screen containers (Safari alone contributes 28), so the grid saturates to 100% during the walk and the skip check suppresses every probe: zero web nodes discovered, silently, exit 0. With coverage off, every grid point is probed; duplicate hits are collapsed by PID and frame de-duplication, and `--web-content-max-points` bounds the cost.
2. **Grid step defaults to 25 pt, not the library's 50 pt.** Measured against a page of ordinary web controls, a 50 pt grid leaves ~17 pt bands between probe rows and silently missed a standard 20 pt-tall link while still returning a complete-looking tree. 25 pt found every element on the same page; anything smaller only added duplicate hits at quadratically higher cost.

## Other behavior worth knowing

- `--include-web-content` + `--point` is rejected with a clear message: a point lookup already resolves web content across the process boundary.
- Discovered elements are appended to the root Application element's `children` — the process boundary means there is no ancestor chain to nest them under the hosting web view. Consumers matching by label/type/frame are unaffected.
- The cost is why it's opt-in, and it's predictable: each probe point costs ~1.44 ms, so `added_ms ≈ 1.44 × ceil(width/step) × ceil(height/step)`. On a 402x874 pt screen the 25 pt default is 595 probes, measured at **+530 ms to +860 ms** per call depending on the screen (2.3x-4.8x baseline). Halving the step quadruples that. `--web-content-max-points` caps the worst case: on a screen with no web content it cuts the overhead from +530 ms to +52 ms with no loss in what's found.
- **Only content currently on screen is discovered.** Hit-testing samples screen points, so one call sees exactly the current viewport; scroll and call again to reach the rest. Measured on a 40-item page: ~6 items per call at any grid step, and the set tracks the viewport as it scrolls.
- With the flag **on**, natively walked elements also carry `is_remote: "recursive"`; only `point_grid` marks grid-discovered content. Whole-screen probing can also return other out-of-process UI, such as the status bar. `FBAccessibilityRemoteContentOptions.region` is the unused knob that would bound both.
- The fixture exercises WKWebView; SFSafariViewController shares the same out-of-process WebKit mechanism, which is why the help names both.
- **Help goldens are deliberately untouched.** `Tests/Goldens/**` is capture-time release evidence whose `provenance.json` pins a `stable_contract_sha256`; hand-editing the help stdout would break that contract, and `scripts/regenerate-goldens.sh` recaptures the new help output at the next release regeneration.

## Mechanical / safe to skim

`ContentView` screen routing (+4), the launch-helper wait key (+2, keyed on a native element since web content is invisible to a plain `describe-ui`), and the 3-line `is_remote` addition to the test JSON decoder.

## Verification

- `swift build` clean; full non-E2E suite 221/221.
- All 14 DescribeUI tests pass, including both E2E legs on a booted iPhone 17 Pro (iOS 26.5) simulator. The E2E tests are gated behind `AXE_E2E=1` like the existing simulator tests.
- Manual verification output shown in Visuals above.

## Risk & rollback

Flag-off behavior is byte-identical (asserted end-to-end by `describeUIOmitsWebContentByDefault`), no dependency changes, single commit — revert is one clean `git revert`.

