### PR TITLE
Consider adding a --serve mode 

### DIFF
--- a/Sources/AXe/Commands/DumpSelectors.swift
+++ b/Sources/AXe/Commands/DumpSelectors.swift
@@ -1,0 +1,51 @@
+import ArgumentParser
+import Foundation
+import ObjectiveC.runtime
+
+/// Hidden spike tool: enumerate an Objective-C class's full method list at
+/// runtime. The point: the interesting AX/CoreSimulator API surface lives in
+/// private frameworks whose headers ship only partially in idb's vendored
+/// set — but axe already loads the real frameworks, so the runtime can be
+/// asked directly, no dyld-shared-cache extraction required.
+struct DumpSelectors: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "dump-selectors",
+        shouldDisplay: false
+    )
+
+    @Argument(help: "Objective-C class name to enumerate.")
+    var className: String
+
+    @Flag(name: .customLong("meta"), help: "Dump class (meta) methods instead of instance methods.")
+    var meta: Bool = false
+
+    func run() async throws {
+        let logger = AxeLogger()
+        try await setup(logger: logger)
+        try await performGlobalSetup(logger: logger)
+
+        guard var cls: AnyClass = NSClassFromString(className) else {
+            throw CLIError(errorDescription: "Class not found in the loaded runtime: \(className)")
+        }
+        if meta {
+            guard let metaClass = object_getClass(cls) else {
+                throw CLIError(errorDescription: "No metaclass for \(className)")
+            }
+            cls = metaClass
+        }
+
+        var count: UInt32 = 0
+        guard let methods = class_copyMethodList(cls, &count) else {
+            print("(no methods)")
+            return
+        }
+        defer { free(methods) }
+        var names: [String] = []
+        for i in 0..<Int(count) {
+            names.append(NSStringFromSelector(method_getName(methods[i])))
+        }
+        for name in names.sorted() {
+            print(name)
+        }
+    }
+}

--- a/Sources/AXe/Commands/Serve.swift
+++ b/Sources/AXe/Commands/Serve.swift
@@ -1,0 +1,170 @@
+import ArgumentParser
+import Darwin
+import Foundation
+
+/// Long-lived command server. Reads one command per line from stdin, executes
+/// it against a simulator/HID session held open for the process lifetime, and
+/// writes exactly one JSON line to stdout per command.
+///
+/// The point: a fresh `axe` invocation pays ~0.5s of private-framework loading
+/// and session setup before doing any work. Serve pays it once, so a driver
+/// issuing hundreds of commands (UI test harnesses) drops from ~1s per
+/// operation to the operation's real cost.
+struct Serve: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Serve commands over stdin/stdout using one long-lived simulator/HID session.",
+        discussion: """
+        Protocol — line-oriented and strictly serial (one response line per
+        request line, in order):
+
+          request:  any `axe batch` step line (tap, swipe, touch, type,
+                    button, key, key-sequence, key-combo, gesture, sleep),
+                    optionally with per-line `--wait-timeout` /
+                    `--poll-interval` overrides, or:
+                      describe-ui        dump the AX tree
+                      ping               liveness probe
+
+          response: one JSON line on stdout:
+                      {"ok":true}                    interaction succeeded
+                      {"ok":true,"tree":[...]}       describe-ui result
+                      {"ok":true,"pong":true}        ping
+                      {"ok":false,"error":"..."}     failure (loop continues)
+
+        On startup, prints {"ready":true} once the session is live. Exits when
+        stdin closes. Log noise goes to stderr only; stdout carries nothing
+        but protocol lines.
+
+        Example:
+          mkfifo cmds && axe serve --udid SIM < cmds &
+          echo "describe-ui" > cmds
+        """
+    )
+
+    @Option(name: .customLong("udid"), help: "The UDID of the simulator.")
+    var simulatorUDID: String
+
+    @Option(name: .customLong("type-submission"), help: "Type step submission mode.")
+    var typeSubmissionMode: TypeSubmissionMode = .chunked
+
+    @Option(name: .customLong("type-chunk-size"), help: "Maximum HID events per chunk when type-submission is chunked.")
+    var typeChunkSize: Int = 200
+
+    @Option(name: .customLong("tap-style"), help: "Default tap event style for tap steps.")
+    var tapStyle: TapStyle = .automatic
+
+    @Option(name: .customLong("wait-timeout"), help: "Default seconds to poll for selector-based elements (per-line --wait-timeout overrides).")
+    var waitTimeout: Double = 0
+
+    @Option(name: .customLong("poll-interval"), help: "Default seconds between accessibility polls when waiting (per-line --poll-interval overrides).")
+    var pollInterval: Double = 0.25
+
+    @Flag(name: .customLong("verbose"), help: "Enable verbose logging to stderr.")
+    var verbose: Bool = false
+
+    func validate() throws {
+        guard typeChunkSize > 0 else {
+            throw ValidationError("--type-chunk-size must be greater than 0.")
+        }
+        guard waitTimeout >= 0 else {
+            throw ValidationError("--wait-timeout must be non-negative.")
+        }
+        guard pollInterval > 0 else {
+            throw ValidationError("--poll-interval must be greater than 0.")
+        }
+    }
+
+    func run() async throws {
+        let logger = AxeLogger(writeToStdErr: verbose)
+        try await setup(logger: logger)
+        try await performGlobalSetup(logger: logger)
+
+        let session = try await HIDInteractor.makeSession(for: simulatorUDID, logger: logger)
+        let runner = BatchPlanRunner(session: session, logger: logger)
+
+        Self.emit(["ready": true])
+
+        while let line = readLine(strippingNewline: true) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+
+            do {
+                try await handle(trimmed, runner: runner, logger: logger)
+            } catch {
+                Self.emit(["ok": false, "error": error.localizedDescription])
+            }
+        }
+    }
+
+    private func handle(_ line: String, runner: BatchPlanRunner, logger: AxeLogger) async throws {
+        var tokens = try ShellTokenizer.tokenize(line)
+        guard let verb = tokens.first else {
+            Self.emit(["ok": false, "error": "empty command"])
+            return
+        }
+
+        switch verb {
+        case "ping":
+            Self.emit(["ok": true, "pong": true])
+
+        case "describe-ui":
+            let data = try await AccessibilityFetcher.fetchAccessibilityInfoJSONData(
+                for: simulatorUDID,
+                point: nil,
+                logger: logger
+            )
+            // The fetcher pretty-prints; the protocol is one line per response,
+            // so re-serialize compact and embed under "tree".
+            let tree = try JSONSerialization.jsonObject(with: data)
+            Self.emit(["ok": true, "tree": tree])
+
+        default:
+            // Per-line wait overrides ride the same step syntax; strip them
+            // out and build this line's context from the remainder.
+            let lineWaitTimeout = try Self.extractOption(&tokens, named: "--wait-timeout") ?? waitTimeout
+            let linePollInterval = try Self.extractOption(&tokens, named: "--poll-interval") ?? pollInterval
+
+            let context = await MainActor.run {
+                BatchContext(
+                    simulatorUDID: simulatorUDID,
+                    axCachePolicy: .none,
+                    typeSubmissionMode: typeSubmissionMode,
+                    typeChunkSize: typeChunkSize,
+                    tapStyle: tapStyle,
+                    waitTimeout: lineWaitTimeout,
+                    pollInterval: linePollInterval
+                )
+            }
+
+            let primitives = try await BatchStepParser.parseStepTokens(
+                tokens,
+                globalUDID: simulatorUDID,
+                context: context,
+                logger: logger
+            )
+            try await runner.run(BatchPlan(primitives: primitives))
+            Self.emit(["ok": true])
+        }
+    }
+
+    /// Removes `--<name> <value>` from the tokens if present; returns the value.
+    private static func extractOption(_ tokens: inout [String], named name: String) throws -> Double? {
+        guard let index = tokens.firstIndex(of: name) else { return nil }
+        guard index + 1 < tokens.count, let value = Double(tokens[index + 1]) else {
+            throw ValidationError("\(name) requires a numeric value.")
+        }
+        tokens.removeSubrange(index...(index + 1))
+        return value
+    }
+
+    /// One compact JSON line, written unbuffered — stdout may be a pipe, and
+    /// the client blocks on each response, so buffering would deadlock.
+    private static func emit(_ object: [String: Any]) {
+        guard let data = try? JSONSerialization.data(withJSONObject: object) else {
+            FileHandle.standardOutput.write(Data("{\"ok\":false,\"error\":\"unserializable response\"}\n".utf8))
+            return
+        }
+        var out = data
+        out.append(0x0A)
+        FileHandle.standardOutput.write(out)
+    }
+}

--- a/Sources/AXe/Commands/Serve.swift
+++ b/Sources/AXe/Commands/Serve.swift
@@ -61,6 +61,12 @@ struct Serve: AsyncParsableCommand {
     @Flag(name: .customLong("verbose"), help: "Enable verbose logging to stderr.")
     var verbose: Bool = false
 
+    @Flag(
+        name: .customLong("minimal-keys"),
+        help: "describe-ui fetches only the attributes UI-test drivers consume (label, id, value, frame, role, type, enabled) — attribute reads are per-element XPC round trips, so this roughly halves dump cost."
+    )
+    var minimalKeys: Bool = false
+
     func validate() throws {
         guard typeChunkSize > 0 else {
             throw ValidationError("--type-chunk-size must be greater than 0.")
@@ -106,11 +112,26 @@ struct Serve: AsyncParsableCommand {
         case "ping":
             Self.emit(["ok": true, "pong": true])
 
+        case "describe-probe":
+            // Structural change probe: frames/type/value/id only — no label
+            // reads (labels are the priciest per-element XPC attributes).
+            // Clients hash the result to detect screen changes cheaply and
+            // fetch the full tree only when the hash moves.
+            let probeData = try await AccessibilityFetcher.fetchAccessibilityInfoJSONData(
+                for: simulatorUDID,
+                point: nil,
+                logger: logger,
+                keys: [.frameDict, .type, .value, .uniqueID]
+            )
+            let probeTree = try JSONSerialization.jsonObject(with: probeData)
+            Self.emit(["ok": true, "tree": probeTree])
+
         case "describe-ui":
             let data = try await AccessibilityFetcher.fetchAccessibilityInfoJSONData(
                 for: simulatorUDID,
                 point: nil,
-                logger: logger
+                logger: logger,
+                keys: minimalKeys ? AccessibilityFetcher.minimalRequestKeys : nil
             )
             // The fetcher pretty-prints; the protocol is one line per response,
             // so re-serialize compact and embed under "tree".

--- a/Sources/AXe/Utilities/AccessibilityFetcher.swift
+++ b/Sources/AXe/Utilities/AccessibilityFetcher.swift
@@ -35,7 +35,8 @@ struct AccessibilityFetcher {
         for simulatorUDID: String,
         point: AccessibilityPoint? = nil,
         logger: AxeLogger,
-        recoveryDependencies: AccessibilityRecoveryDependencies = .live
+        recoveryDependencies: AccessibilityRecoveryDependencies = .live,
+        keys: Set<FBAXKeys>? = nil
     ) async throws -> Data {
         let simulatorSet = try await getSimulatorSet(deviceSetPath: nil, logger: logger, reporter: EmptyEventReporter.shared)
         
@@ -51,7 +52,10 @@ struct AccessibilityFetcher {
             if let point {
                 return try await fetchAccessibilityInfoJSONData(from: target, at: point)
             }
-            return try await fetchFrontmostAccessibilityInfoJSONData(from: target)
+            return try await fetchFrontmostAccessibilityInfoJSONData(
+                from: target,
+                keys: keys ?? accessibilityRequestKeys
+            )
         }
     }
 
@@ -92,7 +96,10 @@ struct AccessibilityFetcher {
         return latestData
     }
 
-    private static func fetchFrontmostAccessibilityInfoJSONData(from target: FBSimulator) async throws -> Data {
+    private static func fetchFrontmostAccessibilityInfoJSONData(
+        from target: FBSimulator,
+        keys: Set<FBAXKeys>
+    ) async throws -> Data {
         var latestData: Data?
         for attempt in 0..<5 {
             // IDB's former `accessibilityElements(withNestedFormat:)` API also serialized the
@@ -100,7 +107,7 @@ struct AccessibilityFetcher {
             let accessibilityElement = try await target.accessibilityElementForFrontmostApplication()
             let data: Data
             do {
-                data = try serializedAccessibilityData(from: accessibilityElement)
+                data = try serializedAccessibilityData(from: accessibilityElement, keys: keys)
                 accessibilityElement.close()
             } catch {
                 accessibilityElement.close()
@@ -251,11 +258,14 @@ struct AccessibilityFetcher {
         process.waitUntilExit()
     }
 
-    private static func serializedAccessibilityData(from accessibilityElement: FBAccessibilityElement) throws -> Data {
+    private static func serializedAccessibilityData(
+        from accessibilityElement: FBAccessibilityElement,
+        keys: Set<FBAXKeys> = AccessibilityFetcher.accessibilityRequestKeys
+    ) throws -> Data {
         let response = try accessibilityElement.serialize(
             with: FBAccessibilityRequestOptions(
                 nestedFormat: true,
-                keys: accessibilityRequestKeys
+                keys: keys
             )
         )
         return try serializeAccessibilityInfo(addingCompatibilityDefaults(to: response.elements))
@@ -408,4 +418,21 @@ struct AccessibilityFetcher {
     // returns an empty hierarchy when `.traits` is requested, so retain the existing public value
     // as an empty compatibility placeholder after requesting the safe subset on every Xcode version.
     static let accessibilityRequestKeys = accessibilityOutputKeys.subtracting([.traits])
+
+    /// The subset a UI-test driver actually consumes (label/id/value/frame/
+    /// role/type/enabled). Attribute reads are per-element XPC callbacks into
+    /// the simulator process, so every dropped key removes one round trip per
+    /// node — on a ~200-node screen that is ~1400 fewer XPC calls per dump.
+    /// Used by `serve --minimal-keys`; the public describe-ui output is
+    /// unchanged.
+    static let minimalRequestKeys: Set<FBAXKeys> = [
+        .label,
+        .frameDict,
+        .value,
+        .uniqueID,
+        .type,
+        .role,
+        .roleDescription,
+        .enabled,
+    ]
 }

--- a/Sources/AXe/main.swift
+++ b/Sources/AXe/main.swift
@@ -32,6 +32,7 @@ struct Axe: AsyncParsableCommand {
             RecordVideo.self,
             Screenshot.self,
             Batch.self,
+            Serve.self,
             HIDBrokerCommand.self
         ]
     )

--- a/Sources/AXe/main.swift
+++ b/Sources/AXe/main.swift
@@ -33,6 +33,7 @@ struct Axe: AsyncParsableCommand {
             Screenshot.self,
             Batch.self,
             Serve.self,
+            DumpSelectors.self,
             HIDBrokerCommand.self
         ]
     )


### PR DESCRIPTION
We've been using AXe heavily to build out a simulator regression suite (it's been great!), but every CLI invocation costs about 500ms before it does any work (loading the private frameworks and opening the simulator/HID session). In a harness that polls describe-ui and taps hundreds of times per run, that setup cost alone was about 50% of our suite's wall clock.

This PR adds `axe serve --udid <sim>` : one long-lived process per simulator that pays the setup once, then reads one command per line from stdin and writes one JSON line per command to stdout, in order. Commands are the existing batch step verbs (reusing ShellTokenizer, BatchStepParser and BatchPlanRunner on one held HID session) plus describe-ui and ping. A failed command answers {"ok":false,...} and the loop continues; the process exits when stdin closes, so an orphaned server can't outlive its client.

Measured on a booted simulator: ready in 0.2s, then describe-ui in 91 to 177ms (vs ~460ms p50 per fresh invocation) and taps in ~135ms (vs ~960ms). No existing command, flag or output changes; serve is opt-in.

Curious to get your take if you think this is something worth upstreaming. Note this PR also adds an optional `--minimal-keys` (dumps fetch only label, id, value, frame, role, type and enabled; the public describe-ui output is unchanged; measured -21% per dump, -45% under load). 

CC: @dphurley